### PR TITLE
Add PDFPreprocessor that uses pdftotree

### DIFF
--- a/fonduer/__init__.py
+++ b/fonduer/__init__.py
@@ -15,6 +15,7 @@ from fonduer.models import (SnorkelSession, Document, Phrase, Figure,
                             candidate_subclass)
 from fonduer.parser import HTMLPreprocessor
 from fonduer.parser import OmniParser
+from fonduer.parser import PDFPreprocessor
 from fonduer.snorkel.annotations import load_gold_labels
 from fonduer.snorkel.learning import GenerativeModel, SparseLogisticRegression
 from fonduer.snorkel.matchers import (RegexMatchSpan, DictionaryMatch,


### PR DESCRIPTION
Add a PDFPreprocessor to leverage pdftotree.

Rather than an HTMLPreprocessor, uses can use this:

```py
# docs_path = os.environ['FONDUERHOME'] + '/tutorials/hardware/data/html/'
pdf_path = os.environ['FONDUERHOME'] + '/tutorials/hardware/data/pdf/'

max_docs = float('inf')
doc_preprocessor = PDFPreprocessor(pdf_path, max_docs=max_docs)
```