### PR TITLE
Only clear candidates associated with a CandidateExtractor

### DIFF
--- a/fonduer/candidates/models/candidate.py
+++ b/fonduer/candidates/models/candidate.py
@@ -150,9 +150,9 @@ def candidate_subclass(
             "__argnames__": args,
         }
 
-        # Create named arguments, i.e. the entity mentions comprising the relation
-        # mention
-        # For each entity mention: id, cid ("canonical id"), and pointer to Context
+        # Create named arguments, i.e. the entity mentions comprising the
+        # relation mention. For each entity mention: id, cid ("canonical id"),
+        # and pointer to Context
         unique_args = []
         for arg in args:
 


### PR DESCRIPTION
Rather than clearing ALL candidates, the clear() function of a CandidateExtractor only clears the candidates associated with it's candidate_class. Provides a new function for clearing ALL candidates.