### PR TITLE
Only apply split at the candidate level

### DIFF
--- a/fonduer/candidates/mentions.py
+++ b/fonduer/candidates/mentions.py
@@ -180,22 +180,18 @@ class MentionExtractor(UDFRunner):
         """Call the MentionExtractorUDF."""
         super(MentionExtractor, self).apply(xs, split=split, **kwargs)
 
-    def clear(self, session, split, **kwargs):
+    def clear(self, session, **kwargs):
         """Delete Mentions of each class in the extractor from the given split."""
         for mention_class in self.mention_classes:
-            logger.info(
-                "Clearing table: {} (split {})".format(
-                    mention_class.__tablename__, split
-                )
-            )
+            logger.info("Clearing table: {}".format(mention_class.__tablename__))
             session.query(Mention).filter(
                 Mention.type == mention_class.__tablename__
-            ).filter(Mention.split == split).delete()
+            ).delete()
 
-    def clear_all(self, session, split, **kwargs):
+    def clear_all(self, session, **kwargs):
         """Delete all Mentions from given split the database."""
         logger.info("Clearing ALL Mentions.")
-        session.query(Mention).filter(Mention.split == split).delete()
+        session.query(Mention).delete()
 
 
 class MentionExtractorUDF(UDF):
@@ -223,12 +219,11 @@ class MentionExtractorUDF(UDF):
 
         super(MentionExtractorUDF, self).__init__(**kwargs)
 
-    def apply(self, context, clear, split, **kwargs):
+    def apply(self, context, clear, **kwargs):
         """Extract mentions from the given Context.
 
         :param context: A document to process.
         :param clear: Whether or not to clear the existing database entries.
-        :param split: Which split to use.
         """
 
         # Iterate over each mention class
@@ -243,8 +238,7 @@ class MentionExtractorUDF(UDF):
                 self.child_context_set.add(tc)
 
             # Generates and persists mentions
-            mention_args = {"split": split}
-            mention_args["document_id"] = context.id
+            mention_args = {"document_id": context.id}
             for child_context in self.child_context_set:
                 # Assemble mention arguments
                 for arg_name in mention_class.__argnames__:

--- a/fonduer/candidates/models/mention.py
+++ b/fonduer/candidates/models/mention.py
@@ -26,7 +26,6 @@ class Mention(_meta.Base):
     __tablename__ = "mention"
     id = Column(Integer, primary_key=True)
     type = Column(String, nullable=False)
-    split = Column(Integer, nullable=False, default=0, index=True)
 
     __mapper_args__ = {"polymorphic_identity": "mention", "polymorphic_on": type}
 

--- a/tests/candidates/test_candidates.py
+++ b/tests/candidates/test_candidates.py
@@ -84,7 +84,7 @@ def test_cand_gen(caplog):
         [part_ngrams, temp_ngrams, volt_ngrams],
         [part_matcher, temp_matcher, volt_matcher],
     )
-    mention_extractor.apply(docs, split=0, parallelism=PARALLEL)
+    mention_extractor.apply(docs, parallelism=PARALLEL)
 
     assert session.query(Part).count() == 234
     assert session.query(Volt).count() == 108

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -167,8 +167,7 @@ def test_e2e(caplog):
         [Part, Temp], [part_ngrams, temp_ngrams], [part_matcher, temp_matcher]
     )
 
-    for i, docs in enumerate([train_docs, dev_docs, test_docs]):
-        mention_extractor.apply(docs, split=i, parallelism=PARALLEL)
+    mention_extractor.apply(docs, parallelism=PARALLEL)
 
     assert session.query(Part).filter(Part.split == 0).count() == 201
     assert session.query(Part).filter(Part.split == 1).count() == 20


### PR DESCRIPTION
Rather than applying a split at both the MentionExtractor and CandidateExtractor, only apply a split at the CandidateExtractor.