### PR TITLE
Add flake8 to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,7 @@ repos:
     hooks:
     - id: black
       language_version: python3.6
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: master
+    hooks:
+    -   id: flake8

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,8 @@ check:
 	isort -rc -c tests/
 	black fonduer/ --check
 	black tests/ --check
-	# This is our code-style check. We currently allow the following exceptions:
-	#   - E731: do not assign a lambda expression, use a def
-	#   - W503: line break before binary operator
-	#   - E741: do not use variables named 'l', 'O', or 'I'
-	#   - E203: whitespace before ':'
-	flake8 fonduer/ --count --max-line-length=88 --statistics --ignore=E731,W503,E741,E203
-	flake8 tests/ --count --max-line-length=88 --statistics --ignore=E731,W503,E741,E203
-
+	flake8 fonduer/
+	flake8 tests/
 docs:
 	sphinx-build -b html docs/ _build/html
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,14 @@ test=pytest
 
 [tool:pytest]
 addopts = -v -rsXx
+
+# This is our code-style check. We currently allow the following exceptions:
+#   - E731: do not assign a lambda expression, use a def
+#   - W503: line break before binary operator
+#   - E741: do not use variables named 'l', 'O', or 'I'
+#   - E203: whitespace before ':'
+[flake8]
+count = True
+max-line-length = 88
+statistics = True
+ignore = E731,W503,E741,E203


### PR DESCRIPTION
Don't know why this wasn't there in the first place. Run flake8 checks with our pre-commit hooks.