### PR TITLE
Skip TemporarySpan if it is an empty string

### DIFF
--- a/fonduer/candidates/mentions.py
+++ b/fonduer/candidates/mentions.py
@@ -73,13 +73,13 @@ class Ngrams(MentionSpace):
                             char_end=start + m.start(1) - 1,
                             sentence=context,
                         )
-                        if ts1 not in seen:
+                        if ts1 not in seen and ts1.get_span():
                             seen.add(ts1)
                             yield ts1
                         ts2 = TemporarySpan(
                             char_start=start + m.end(1), char_end=end, sentence=context
                         )
-                        if ts2 not in seen:
+                        if ts2 not in seen and ts2.get_span():
                             seen.add(ts2)
                             yield ts2
 


### PR DESCRIPTION
When a text is "BC548BG-", the output of `Ngram.apply` is currently TemporarySpan(s) with "BC548BG-", "BC548BG", and "" (empty).
This patch skips if TemporarySpan contains an empty string.