### PR TITLE
Check if poppler-utils is installed AND the version is 0.36.0+

### DIFF
--- a/fonduer/parser/visual_linker.py
+++ b/fonduer/parser/visual_linker.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import shutil
 import subprocess
 from builtins import object, range, str, zip
 from collections import OrderedDict, defaultdict
@@ -26,6 +27,19 @@ class VisualLinker(object):
             u"([\(\)\,\?\u2212\u201C\u201D\u2018\u2019\u00B0\*']|(?<!http):|\.$|\.\.\.)"
         )
         self.separators = re.compile(delimiters)
+
+        # Check if poppler-utils is installed AND the version is 0.36.0 or above
+        if shutil.which("pdfinfo") is None or shutil.which("pdftotext") is None:
+            raise RuntimeError("poppler-utils is not installed or they are not in PATH")
+        version = subprocess.check_output(
+            "pdfinfo -v", shell=True, stderr=subprocess.STDOUT, universal_newlines=True
+        )
+        m = re.search(r"\d\.\d{2}\.\d", version)
+        if int(m.group(0).replace(".", "")) < 360:
+            raise RuntimeError(
+                "Installed poppler-utils's version is %s, but should be 0.36.0 or above"
+                % m.group(0)
+            )
 
     def parse_visual(self, document_name, sentences, pdf_path):
         self.sentences = sentences


### PR DESCRIPTION
If poppler-utils is not installed, the following error occurs when executing `Parser.apply` (with `visual=True`):

```
  File "/home/vagrant/fonduer-tutorials/.venv/lib/python3.6/site-packages/fonduer/utils/udf.py", line 169, in run
    for y in self.apply(x, **self.apply_kwargs):
  File "/home/vagrant/fonduer-tutorials/.venv/lib/python3.6/site-packages/fonduer/parser/parser.py", line 143, in apply
    document.name, document.sentences, self.pdf_path
  File "/home/vagrant/fonduer-tutorials/.venv/lib/python3.6/site-packages/fonduer/parser/visual_linker.py", line 38, in parse_visual
    self.extract_pdf_words()
  File "/home/vagrant/fonduer-tutorials/.venv/lib/python3.6/site-packages/fonduer/parser/visual_linker.py", line 54, in extract_pdf_words
    for i in range(1, int(num_pages) + 1):
ValueError: invalid literal for int() with base 10: b''
```

The problem is that the error message does not tell you the root cause of the error, i.e., absence of `pdfinfo`.
This happens on v0.2.3 and theoretically on master (6f92b60d9c3dfab23e341ebcb7e655e46bf37c1e).