### PR TITLE
Change language_version for black to python3 to support python3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: stable 
     hooks:
     - id: black
-      language_version: python3.6
+      language_version: python3
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: master
     hooks:


### PR DESCRIPTION
This patch fixes an error that happens when only python3.7 is installed and python3.6 is not.

```
(venv) My-MBP:fonduer hiromu$ git commit --amend
[INFO] Initializing environment for https://github.com/asottile/seed-isort-config.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-isort.
[INFO] Initializing environment for https://github.com/ambv/black.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Installing environment for https://github.com/asottile/seed-isort-config.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/ambv/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: Command: ('/Users/hiromu/workspace/fonduer/venv/bin/python3.7', '-mvirtualenv', '/Users/hiromu/.cache/pre-commit/repokrxu_ynt/py_env-python3.6', '-p', 'python3.6')
Return code: 3
Expected return code: 0
Output: 
    The path python3.6 (from --python=python3.6) does not exist
    
Errors: (none)

Check the log at /Users/hiromu/.cache/pre-commit/pre-commit.log
```