### PR TITLE
Changed to single worker UDF queue filling; Changed DocPreprocessor and subclasses yield objects

### DIFF
--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -151,9 +151,9 @@ class ParserUDF(UDF):
             self.pdf_path = pdf_path
             self.vizlink = VisualLinker()
 
-    def apply(self, x, **kwargs):
-        # The document is the Document model. Text is string representation.
-        document, text = x
+    def apply(self, document, **kwargs):
+        # The document is the Document model
+        text = document.text
         if self.visual:
             if not self.pdf_path:
                 warnings.warn(
@@ -418,7 +418,10 @@ class ParserUDF(UDF):
                     if attr.find("style") >= 0:
                         cur_style_index = index
                         break
-                styles = state["root"].find("head").find("style")
+                head = state["root"].find("head")
+                styles = None
+                if head is not None:
+                    styles = head.find("style")
                 if styles is not None:
                     for x in list(context_node.attrib.items()):
                         if x[0] == "class":

--- a/src/fonduer/parser/preprocessors/doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/doc_preprocessor.py
@@ -26,28 +26,30 @@ class DocPreprocessor(object):
         """
         doc_count = 0
         for fp in self.all_files:
-            file_name = os.path.basename(fp)
-            if self._can_read(file_name):
-                for doc, text in self.parse_file(fp, file_name):
-                    yield doc, text
-                    doc_count += 1
-                    if doc_count >= self.max_docs:
-                        return
+            for doc in self.get_docs_for_path(fp):
+                yield doc
+                doc_count += 1
+                if doc_count >= self.max_docs:
+                    return
 
-    def parse_by_index(self, index):
+    def __getitem__(self, index):
         fp = self.all_files[index]
-        file_name = os.path.basename(fp)
-        if self._can_read(file_name):
-            for doc, text in self.parse_file(fp, file_name):
-                yield doc, text
+        return [doc for doc in self.get_docs_for_path(fp)]
 
     def __len__(self):
-        """Provide a len attribute based on max_docs and number of files in folder."""
-        num_docs = min(len(self.all_files), self.max_docs)
-        return num_docs
+        raise NotImplementedError(
+            "One generec file can yield more than one Document objects, "
+            "so length can not be yielded before we process all files"
+        )
 
     def __iter__(self):
         return self.generate()
+
+    def get_docs_for_path(self, fp):
+        file_name = os.path.basename(fp)
+        if self._can_read(file_name):
+            for doc in self.parse_file(fp, file_name):
+                yield doc
 
     def get_stable_id(self, doc_id):
         return "%s::document:0:0" % doc_id

--- a/src/fonduer/parser/preprocessors/html_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/html_doc_preprocessor.py
@@ -13,15 +13,23 @@ class HTMLDocPreprocessor(DocPreprocessor):
     def parse_file(self, fp, file_name):
         with codecs.open(fp, encoding=self.encoding) as f:
             soup = BeautifulSoup(f, "lxml")
-            for text in soup.find_all("html"):
-                name = os.path.basename(fp)[: os.path.basename(fp).rfind(".")]
-                stable_id = self.get_stable_id(name)
-                yield Document(
-                    name=name,
-                    stable_id=stable_id,
-                    text=str(text),
-                    meta={"file_name": file_name},
-                ), str(text)
+            all_html_elements = soup.find_all("html")
+            if len(all_html_elements) != 1:
+                raise NotImplementedError("Expecting one html element per html file")
+            text = all_html_elements[0]
+            name = os.path.basename(fp)[: os.path.basename(fp).rfind(".")]
+            stable_id = self.get_stable_id(name)
+            yield Document(
+                name=name,
+                stable_id=stable_id,
+                text=str(text),
+                meta={"file_name": file_name},
+            )
+
+    def __len__(self):
+        """Provide a len attribute based on max_docs and number of files in folder."""
+        num_docs = min(len(self.all_files), self.max_docs)
+        return num_docs
 
     def _can_read(self, fpath):
         return fpath.lower().endswith("html")  # includes both .html and .xhtml

--- a/src/fonduer/parser/preprocessors/text_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/text_doc_preprocessor.py
@@ -13,6 +13,9 @@ class TextDocPreprocessor(DocPreprocessor):
             name = os.path.basename(fp).rsplit(".", 1)[0]
             stable_id = self.get_stable_id(name)
             doc = Document(
-                name=name, stable_id=stable_id, meta={"file_name": file_name}
+                name=name,
+                stable_id=stable_id,
+                meta={"file_name": file_name},
+                text=f.read(),
             )
-            yield doc, f.read()
+            yield doc

--- a/src/fonduer/parser/preprocessors/tsv_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/tsv_doc_preprocessor.py
@@ -13,6 +13,9 @@ class TSVDocPreprocessor(DocPreprocessor):
                 (doc_name, doc_text) = line.split("\t")
                 stable_id = self.get_stable_id(doc_name)
                 doc = Document(
-                    name=doc_name, stable_id=stable_id, meta={"file_name": file_name}
+                    name=doc_name,
+                    stable_id=stable_id,
+                    meta={"file_name": file_name},
+                    text=doc_text,
                 )
-                yield doc, doc_text
+                yield doc

--- a/src/fonduer/parser/preprocessors/xml_multidoc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/xml_multidoc_preprocessor.py
@@ -40,7 +40,7 @@ class XMLMultiDocPreprocessor(DocPreprocessor):
             if self.keep_xml_tree:
                 meta["root"] = et.tostring(doc)
             stable_id = self.get_stable_id(doc_id)
-            yield Document(name=doc_id, stable_id=stable_id, meta=meta), text
+            yield Document(name=doc_id, stable_id=stable_id, meta=meta, text=text)
 
     def _can_read(self, fpath):
         return fpath.endswith(".xml")

--- a/src/fonduer/utils/udf.py
+++ b/src/fonduer/utils/udf.py
@@ -1,5 +1,5 @@
 import logging
-from multiprocessing import JoinableQueue, Manager, Pool, Process
+from multiprocessing import JoinableQueue, Manager, Process
 from queue import Empty
 
 from fonduer.meta import Meta, new_sessionmaker
@@ -21,14 +21,6 @@ QUEUE_TIMEOUT = 3
 _meta = Meta.init()
 
 
-def async_fill_input_queue(arg_tuple):
-    input_queue = arg_tuple[0]
-    preprocessor = arg_tuple[1]
-    doc_index = arg_tuple[2]
-    for doc_tuple in preprocessor.parse_by_index(doc_index):
-        input_queue.put(doc_tuple)
-
-
 class UDFRunner(object):
     """
     Class to run UDFs in parallel using simple queue-based multiprocessing
@@ -44,10 +36,12 @@ class UDFRunner(object):
         self.session = session
         self.parallelism = parallelism
 
-    def apply(self, xs, clear=True, parallelism=None, progress_bar=True, **kwargs):
+    def apply(
+        self, doc_loader, clear=True, parallelism=None, progress_bar=True, **kwargs
+    ):
         """
-        Apply the given UDF to the set of objects xs, either single or
-        multi-threaded, and optionally calling clear() first.
+        Apply the given UDF to the set of objects returned by the doc_loader, either
+        single or multi-threaded, and optionally calling clear() first.
         """
         # Clear everything downstream of this UDF if requested
         if clear:
@@ -57,17 +51,20 @@ class UDFRunner(object):
         self.logger.info("Running UDF...")
 
         # Setup progress bar
-        if progress_bar and hasattr(xs, "__len__"):
+        if progress_bar:
             self.logger.debug("Setting up progress bar...")
-            self.pb = tqdm(total=len(xs))
+            if hasattr(doc_loader, "__len__"):
+                self.pb = tqdm(total=len(doc_loader))
+            else:
+                self.logger.error("Could not determine size of progress bar")
 
         # Use the parallelism of the class if none is provided to apply
         parallelism = parallelism if parallelism else self.parallelism
-
+        print("parallelism: {}".format(parallelism))
         if parallelism < 2:
-            self.apply_st(xs, clear=clear, **kwargs)
+            self.apply_st(doc_loader, clear=clear, **kwargs)
         else:
-            self.apply_mt(xs, parallelism, clear=clear, **kwargs)
+            self.apply_mt(doc_loader, parallelism, clear=clear, **kwargs)
 
         # Close progress bar
         if self.pb is not None:
@@ -77,33 +74,37 @@ class UDFRunner(object):
     def clear(self, **kwargs):
         raise NotImplementedError()
 
-    def apply_st(self, xs, **kwargs):
+    def apply_st(self, doc_loader, **kwargs):
         """Run the UDF single-threaded, optionally with progress bar"""
         udf = self.udf_class(**self.udf_init_kwargs)
 
         # Run single-thread
-        for x in xs:
+        for doc in doc_loader:
             if self.pb is not None:
                 self.pb.update(1)
 
-            udf.session.add_all(y for y in udf.apply(x, **kwargs))
+            udf.session.add_all(y for y in udf.apply(doc, **kwargs))
 
         # Commit session and close progress bar if applicable
         udf.session.commit()
 
-    def apply_mt(self, xs, parallelism, **kwargs):
+    def apply_mt(self, doc_loader, parallelism, **kwargs):
         """Run the UDF multi-threaded using python multiprocessing"""
         if not _meta.postgres:
             raise ValueError("Fonduer must use PostgreSQL as a database backend.")
 
-        # Create a Queue to feed documents to parsers
+        def fill_input_queue(in_queue, doc_loader, terminal_signal):
+            for doc in doc_loader:
+                in_queue.put(doc)
+            in_queue.put(terminal_signal)
+
+        # Create an input queue to feed documents to UDF workers
         manager = Manager()
         in_queue = manager.Queue()
-
         # Use an output queue to track multiprocess progress
         out_queue = JoinableQueue()
 
-        total_count = len(xs)
+        total_count = len(doc_loader)
 
         # Start UDF Processes
         for i in range(parallelism):
@@ -121,14 +122,16 @@ class UDFRunner(object):
             udf.start()
 
         # Fill input queue with documents
-        pool = Pool(parallelism)
-        in_tuples = ((in_queue, xs, index) for index in range(total_count))
-        pool.map_async(func=async_fill_input_queue, iterable=in_tuples)
+        terminal_signal = UDF.QUEUE_CLOSED
+        in_queue_filler = Process(
+            target=fill_input_queue, args=(in_queue, doc_loader, terminal_signal)
+        )
+        in_queue_filler.start()
 
         count_parsed = 0
         while count_parsed < total_count:
             y = out_queue.get()
-            # Update progress bar whenever an item is processed
+            # Update progress bar whenever an item has been  processed
             if y == UDF.TASK_DONE:
                 count_parsed += 1
                 if self.pb is not None:
@@ -136,8 +139,7 @@ class UDFRunner(object):
             else:
                 raise ValueError("Got non-sentinal output.")
 
-        pool.close()
-        pool.join()
+        in_queue_filler.join()
         in_queue.put(UDF.QUEUE_CLOSED)
 
         for udf in self.udfs:
@@ -179,17 +181,17 @@ class UDF(Process):
         """
         while True:
             try:
-                x = self.in_queue.get(True, QUEUE_TIMEOUT)
-                if x == UDF.QUEUE_CLOSED:
+                doc = self.in_queue.get(True, QUEUE_TIMEOUT)
+                if doc == UDF.QUEUE_CLOSED:
                     self.in_queue.put(UDF.QUEUE_CLOSED)
                     break
-                self.session.add_all(y for y in self.apply(x, **self.apply_kwargs))
+                self.session.add_all(y for y in self.apply(doc, **self.apply_kwargs))
                 self.out_queue.put(UDF.TASK_DONE)
             except Empty:
                 continue
         self.session.commit()
         self.session.close()
 
-    def apply(self, x, **kwargs):
+    def apply(self, doc, **kwargs):
         """This function takes in an object, and returns a generator / set / list"""
         raise NotImplementedError()

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -52,7 +52,7 @@ def test_parse_md_details(caplog):
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
-    doc, text = next(preprocessor.parse_file(docs_path, "md"))
+    doc = next(preprocessor.parse_file(docs_path, "md"))
 
     # Check that doc has a name
     assert doc.name == "md"
@@ -72,7 +72,7 @@ def test_parse_md_details(caplog):
         pdf_path=pdf_path,
         language="en",
     )
-    for _ in parser_udf.apply((doc, text)):
+    for _ in parser_udf.apply(doc):
         pass
 
     # Check that doc has a figure
@@ -153,13 +153,13 @@ def test_spacy_non_english_languages(caplog):
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
-    doc, text = next(preprocessor.parse_file(docs_path, "md"))
+    doc = next(preprocessor.parse_file(docs_path, "md"))
 
     # Create an Parser and parse the md document
     parser_udf = get_parser_udf(
         structural=True, tabular=True, lingual=True, visual=False, language="de"
     )
-    for _ in parser_udf.apply((doc, text)):
+    for _ in parser_udf.apply(doc):
         pass
 
     # Check that doc has sentences
@@ -202,11 +202,11 @@ def test_spacy_non_english_languages(caplog):
 
     # Test japanese alpha tokenization
     docs_path = "tests/data/pure_html/japan.html"
-    doc, text = next(preprocessor.parse_file(docs_path, "md"))
+    doc = next(preprocessor.parse_file(docs_path, "md"))
     parser_udf = get_parser_udf(
         structural=True, tabular=True, lingual=True, visual=False, language="ja"
     )
-    for _ in parser_udf.apply((doc, text)):
+    for _ in parser_udf.apply(doc):
         pass
 
     assert len(doc.sentences) == 289
@@ -227,14 +227,14 @@ def test_warning_on_missing_pdf(caplog):
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
-    doc, text = next(preprocessor.parse_file(docs_path, "md_para"))
+    doc = next(preprocessor.parse_file(docs_path, "md_para"))
 
     # Create an Parser and parse the md document
     parser_udf = get_parser_udf(
         structural=True, tabular=True, lingual=True, visual=True, pdf_path=pdf_path
     )
     with pytest.warns(RuntimeWarning) as record:
-        for _ in parser_udf.apply((doc, text)):
+        for _ in parser_udf.apply(doc):
             pass
     assert len(record) == 1
     assert "Visual parse failed" in record[0].message.args[0]
@@ -249,14 +249,14 @@ def test_warning_on_incorrect_filename(caplog):
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
-    doc, text = next(preprocessor.parse_file(docs_path, "md_para"))
+    doc = next(preprocessor.parse_file(docs_path, "md_para"))
 
     # Create an Parser and parse the md document
     parser_udf = get_parser_udf(
         structural=True, tabular=True, lingual=True, visual=True, pdf_path=pdf_path
     )
     with pytest.warns(RuntimeWarning) as record:
-        for _ in parser_udf.apply((doc, text)):
+        for _ in parser_udf.apply(doc):
             pass
     assert len(record) == 1
     assert "Visual parse failed" in record[0].message.args[0]
@@ -271,7 +271,7 @@ def test_parse_md_paragraphs(caplog):
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
-    doc, text = next(preprocessor.parse_file(docs_path, "md_para"))
+    doc = next(preprocessor.parse_file(docs_path, "md_para"))
 
     # Check that doc has a name
     assert doc.name == "md_para"
@@ -280,7 +280,7 @@ def test_parse_md_paragraphs(caplog):
     parser_udf = get_parser_udf(
         structural=True, tabular=True, lingual=True, visual=True, pdf_path=pdf_path
     )
-    for _ in parser_udf.apply((doc, text)):
+    for _ in parser_udf.apply(doc):
         pass
 
     # Check that doc has a figure
@@ -359,7 +359,7 @@ def test_simple_tokenizer(caplog):
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
-    doc, text = next(preprocessor.parse_file(docs_path, "md"))
+    doc = next(preprocessor.parse_file(docs_path, "md"))
 
     # Check that doc has a name
     assert doc.name == "md"
@@ -368,7 +368,7 @@ def test_simple_tokenizer(caplog):
     parser_udf = get_parser_udf(
         structural=True, lingual=False, visual=True, pdf_path=pdf_path, language=None
     )
-    for _ in parser_udf.apply((doc, text)):
+    for _ in parser_udf.apply(doc):
         pass
 
     logger.info("Doc: {}".format(doc))
@@ -404,7 +404,7 @@ def test_parse_document_diseases(caplog):
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
-    doc, text = next(preprocessor.parse_file(docs_path, "diseases"))
+    doc = next(preprocessor.parse_file(docs_path, "diseases"))
 
     # Check that doc has a name
     assert doc.name == "diseases"
@@ -413,7 +413,7 @@ def test_parse_document_diseases(caplog):
     parser_udf = get_parser_udf(
         structural=True, lingual=True, visual=True, pdf_path=pdf_path
     )
-    for _ in parser_udf.apply((doc, text)):
+    for _ in parser_udf.apply(doc):
         pass
 
     logger.info("Doc: {}".format(doc))
@@ -475,13 +475,13 @@ def test_parse_style(caplog):
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
-    doc, text = next(preprocessor.parse_file(docs_path, "ext_diseases"))
+    doc = next(preprocessor.parse_file(docs_path, "ext_diseases"))
 
     # Create an Parser and parse the diseases document
     parser_udf = get_parser_udf(
         structural=True, lingual=True, visual=True, pdf_path=pdf_path
     )
-    for _ in parser_udf.apply((doc, text)):
+    for _ in parser_udf.apply(doc):
         pass
 
     # Grab the sentences parsed by the Parser


### PR DESCRIPTION
1. Changed UDF input queue filling to one single worker process in order to properly handle input types which cannot be handled properly in parallel only via `__getitem__` calls.
2. `DocPreprocessor` and subclasses now yield `Document` objects instead of `(Document, Text)` tuples.