### PR TITLE
Update path used in readthedocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, os.path.abspath("../src"))
 
 autodoc_mock_imports = [
     "bs4",


### PR DESCRIPTION
Fixes the issue where modules were not being populated because fonduer
was nested in the `src` directory.