### PR TITLE
Stripped doc text and span caching hotfix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Added
 
 Changed
 ^^^^^^^
+* `@j-rausch`_: ``Document.text`` now returns the modified document text, based
+  on the user-defined html-tag stripping in the parsing stage.
 * `@j-rausch`_: ``Ngrams`` now has a ``n_min`` argument to specify a minimum
   number of tokens per extracted n-gram.
 * `@senwu`_: Rename ``gen_learning`` to ``label_learner`` and move to supervision.

--- a/src/fonduer/features/feature_libs/__init__.py
+++ b/src/fonduer/features/feature_libs/__init__.py
@@ -6,16 +6,16 @@ from fonduer.features.feature_libs.visual_features import get_visual_feats
 
 
 def get_all_feats(candidates):
-    for candidate_id, feature_string, feature_value in get_core_feats(candidates):
-        yield candidate_id, feature_string, feature_value
-    for candidate_id, feature_string, feature_value in get_content_feats(candidates):
-        yield candidate_id, feature_string, feature_value
-    for candidate_id, feature_string, feature_value in get_structural_feats(candidates):
-        yield candidate_id, feature_string, feature_value
-    for candidate_id, feature_string, feature_value in get_table_feats(candidates):
-        yield candidate_id, feature_string, feature_value
-    for candidate_id, feature_string, feature_value in get_visual_feats(candidates):
-        yield candidate_id, feature_string, feature_value
+    for candidate_id, feature, value in get_core_feats(candidates):
+        yield candidate_id, feature, value
+    for candidate_id, feature, value in get_content_feats(candidates):
+        yield candidate_id, feature, value
+    for candidate_id, feature, value in get_structural_feats(candidates):
+        yield candidate_id, feature, value
+    for candidate_id, feature, value in get_table_feats(candidates):
+        yield candidate_id, feature, value
+    for candidate_id, feature, value in get_visual_feats(candidates):
+        yield candidate_id, feature, value
 
 
 __all__ = [

--- a/src/fonduer/features/feature_libs/__init__.py
+++ b/src/fonduer/features/feature_libs/__init__.py
@@ -6,16 +6,16 @@ from fonduer.features.feature_libs.visual_features import get_visual_feats
 
 
 def get_all_feats(candidates):
-    for id, f, v in get_core_feats(candidates):
-        yield id, f, v
-    for id, f, v in get_content_feats(candidates):
-        yield id, f, v
-    for id, f, v in get_structural_feats(candidates):
-        yield id, f, v
-    for id, f, v in get_table_feats(candidates):
-        yield id, f, v
-    for id, f, v in get_visual_feats(candidates):
-        yield id, f, v
+    for candidate_id, feature_string, feature_value in get_core_feats(candidates):
+        yield candidate_id, feature_string, feature_value
+    for candidate_id, feature_string, feature_value in get_content_feats(candidates):
+        yield candidate_id, feature_string, feature_value
+    for candidate_id, feature_string, feature_value in get_structural_feats(candidates):
+        yield candidate_id, feature_string, feature_value
+    for candidate_id, feature_string, feature_value in get_table_feats(candidates):
+        yield candidate_id, feature_string, feature_value
+    for candidate_id, feature_string, feature_value in get_visual_feats(candidates):
+        yield candidate_id, feature_string, feature_value
 
 
 __all__ = [

--- a/src/fonduer/features/feature_libs/structural_features.py
+++ b/src/fonduer/features/feature_libs/structural_features.py
@@ -36,13 +36,11 @@ def get_structural_feats(candidates):
             if span.sentence.is_structural():
                 if span.stable_id not in unary_strlib_feats:
                     unary_strlib_feats[span.stable_id] = set()
-                    for feature_str, feature_val in strlib_unary_features(span):
-                        unary_strlib_feats[span.stable_id].add(
-                            (feature_str, feature_val)
-                        )
+                    for feature, value in strlib_unary_features(span):
+                        unary_strlib_feats[span.stable_id].add((feature, value))
 
-                for feature_str, feature_val in unary_strlib_feats[span.stable_id]:
-                    yield candidate.id, FEATURE_PREFIX + feature_str, feature_val
+                for feature, value in unary_strlib_feats[span.stable_id]:
+                    yield candidate.id, FEATURE_PREFIX + feature, value
 
         # Binary candidates
         elif len(args) == 2:
@@ -51,26 +49,19 @@ def get_structural_feats(candidates):
                 for span, prefix in [(span1, "e1_"), (span2, "e2_")]:
                     if span.stable_id not in unary_strlib_feats:
                         unary_strlib_feats[span.stable_id] = set()
-                        for feature_str, feature_val in strlib_unary_features(span):
-                            unary_strlib_feats[span.stable_id].add(
-                                (feature_str, feature_val)
-                            )
+                        for feature, value in strlib_unary_features(span):
+                            unary_strlib_feats[span.stable_id].add((feature, value))
 
-                    for feature_str, feature_val in unary_strlib_feats[span.stable_id]:
-                        combined_str = FEATURE_PREFIX + prefix + feature_str
-                        yield candidate.id, combined_str, feature_val
+                    for feature, value in unary_strlib_feats[span.stable_id]:
+                        yield candidate.id, FEATURE_PREFIX + prefix + feature, value
 
                 if candidate.id not in binary_strlib_feats:
                     binary_strlib_feats[candidate.id] = set()
-                    for feature_str, feature_val in strlib_binary_features(
-                        span1, span2
-                    ):
-                        binary_strlib_feats[candidate.id].add(
-                            (feature_str, feature_val)
-                        )
+                    for feature, value in strlib_binary_features(span1, span2):
+                        binary_strlib_feats[candidate.id].add((feature, value))
 
-                for feature_str, feature_val in binary_strlib_feats[candidate.id]:
-                    yield candidate.id, FEATURE_PREFIX + feature_str, feature_val
+                for feature, value in binary_strlib_feats[candidate.id]:
+                    yield candidate.id, FEATURE_PREFIX + feature, value
         else:
             raise NotImplementedError(
                 "Only handles unary and binary candidates currently"

--- a/src/fonduer/features/feature_libs/structural_features.py
+++ b/src/fonduer/features/feature_libs/structural_features.py
@@ -14,7 +14,7 @@ from fonduer.utils.data_model_utils import (
     lowest_common_ancestor_depth,
 )
 
-FEAT_PRE = "STR_"
+FEATURE_PREFIX = "STR_"
 DEF_VALUE = 1
 
 unary_strlib_feats = {}
@@ -36,32 +36,41 @@ def get_structural_feats(candidates):
             if span.sentence.is_structural():
                 if span.stable_id not in unary_strlib_feats:
                     unary_strlib_feats[span.stable_id] = set()
-                    for f, v in strlib_unary_features(span):
-                        unary_strlib_feats[span.stable_id].add((f, v))
+                    for feature_str, feature_val in strlib_unary_features(span):
+                        unary_strlib_feats[span.stable_id].add(
+                            (feature_str, feature_val)
+                        )
 
-                for f, v in unary_strlib_feats[span.stable_id]:
-                    yield candidate.id, FEAT_PRE + f, v
+                for feature_str, feature_val in unary_strlib_feats[span.stable_id]:
+                    yield candidate.id, FEATURE_PREFIX + feature_str, feature_val
 
         # Binary candidates
         elif len(args) == 2:
             span1, span2 = args
             if span1.sentence.is_structural() or span2.sentence.is_structural():
-                for span, pre in [(span1, "e1_"), (span2, "e2_")]:
+                for span, prefix in [(span1, "e1_"), (span2, "e2_")]:
                     if span.stable_id not in unary_strlib_feats:
                         unary_strlib_feats[span.stable_id] = set()
-                        for f, v in strlib_unary_features(span):
-                            unary_strlib_feats[span.stable_id].add((f, v))
+                        for feature_str, feature_val in strlib_unary_features(span):
+                            unary_strlib_feats[span.stable_id].add(
+                                (feature_str, feature_val)
+                            )
 
-                    for f, v in unary_strlib_feats[span.stable_id]:
-                        yield candidate.id, FEAT_PRE + pre + f, v
+                    for feature_str, feature_val in unary_strlib_feats[span.stable_id]:
+                        combined_str = FEATURE_PREFIX + prefix + feature_str
+                        yield candidate.id, combined_str, feature_val
 
                 if candidate.id not in binary_strlib_feats:
                     binary_strlib_feats[candidate.id] = set()
-                    for f, v in strlib_binary_features(span1, span2):
-                        binary_strlib_feats[candidate.id].add((f, v))
+                    for feature_str, feature_val in strlib_binary_features(
+                        span1, span2
+                    ):
+                        binary_strlib_feats[candidate.id].add(
+                            (feature_str, feature_val)
+                        )
 
-                for f, v in binary_strlib_feats[candidate.id]:
-                    yield candidate.id, FEAT_PRE + f, v
+                for feature_str, feature_val in binary_strlib_feats[candidate.id]:
+                    yield candidate.id, FEATURE_PREFIX + feature_str, feature_val
         else:
             raise NotImplementedError(
                 "Only handles unary and binary candidates currently"

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -642,7 +642,7 @@ class ParserUDF(UDF):
         if self.flatten:
             lxml.etree.strip_tags(root, self.flatten)
         # Assign the text, which was stripped of the 'flatten'-tags, to the document
-        document.text = lxml.etree.tostring(root).decode("utf-8")
+        document.text = lxml.etree.tostring(root, encoding="unicode")
 
         # This dictionary contain the global state necessary to parse a
         # document and each context element. This reflects the relationships

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -642,8 +642,7 @@ class ParserUDF(UDF):
         if self.flatten:
             lxml.etree.strip_tags(root, self.flatten)
         # Assign the text, which was stripped of the 'flatten'-tags, to the document
-        stripped_text = lxml.etree.tostring(root).decode("utf-8")
-        document.text = stripped_text
+        document.text = lxml.etree.tostring(root).decode("utf-8")
 
         # This dictionary contain the global state necessary to parse a
         # document and each context element. This reflects the relationships

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -637,11 +637,13 @@ class ParserUDF(UDF):
         stack = []
 
         root = lxml.html.fromstring(text)
-        document.text = text
 
         # flattens children of node that are in the 'flatten' list
         if self.flatten:
             lxml.etree.strip_tags(root, self.flatten)
+        # Assign the text, which was stripped of the 'flatten'-tags, to the document
+        stripped_text = lxml.etree.tostring(root).decode("utf-8")
+        document.text = stripped_text
 
         # This dictionary contain the global state necessary to parse a
         # document and each context element. This reflects the relationships

--- a/src/fonduer/parser/preprocessors/html_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/html_doc_preprocessor.py
@@ -16,7 +16,9 @@ class HTMLDocPreprocessor(DocPreprocessor):
             all_html_elements = soup.find_all("html")
             if len(all_html_elements) != 1:
                 raise NotImplementedError(
-                    "Expecting one html element per html file: {}".format(file_name)
+                    "Expecting only one html element per html file: {}".format(
+                        file_name
+                    )
                 )
             text = all_html_elements[0]
             name = os.path.basename(fp)[: os.path.basename(fp).rfind(".")]

--- a/src/fonduer/parser/preprocessors/html_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/html_doc_preprocessor.py
@@ -15,7 +15,9 @@ class HTMLDocPreprocessor(DocPreprocessor):
             soup = BeautifulSoup(f, "lxml")
             all_html_elements = soup.find_all("html")
             if len(all_html_elements) != 1:
-                raise NotImplementedError("Expecting one html element per html file")
+                raise NotImplementedError(
+                    "Expecting one html element per html file: {}".format(file_name)
+                )
             text = all_html_elements[0]
             name = os.path.basename(fp)[: os.path.basename(fp).rfind(".")]
             stable_id = self.get_stable_id(name)

--- a/src/fonduer/utils/data_model_utils/structural.py
+++ b/src/fonduer/utils/data_model_utils/structural.py
@@ -2,6 +2,7 @@
 # Structural modality utilities
 ###############################
 
+import functools
 from builtins import str
 
 import numpy as np
@@ -9,9 +10,6 @@ from lxml import etree
 from lxml.html import fromstring
 
 from fonduer.utils.data_model_utils.utils import _to_span
-
-# Cache all etree objects of documents
-etrees = {}
 
 
 def get_tag(mention):
@@ -42,13 +40,15 @@ def get_attributes(mention):
     return span.sentence.html_attrs
 
 
+@functools.lru_cache(maxsize=256)
+def _get_etree_for_text(text):
+    return etree.ElementTree(fromstring(text))
+
+
 def _get_node(sentence):
     # Using caching to speed up retrieve process
-    if sentence.document.id not in etrees:
-        etrees[sentence.document.id] = etree.ElementTree(
-            fromstring(sentence.document.text)
-        )
-    return etrees[sentence.document.id].xpath(sentence.xpath)[0]
+    doc_etree = _get_etree_for_text(sentence.document.text)
+    return doc_etree.xpath(sentence.xpath)[0]
 
 
 def get_parent_tag(mention):

--- a/src/fonduer/utils/data_model_utils/structural.py
+++ b/src/fonduer/utils/data_model_utils/structural.py
@@ -40,7 +40,7 @@ def get_attributes(mention):
     return span.sentence.html_attrs
 
 
-@functools.lru_cache(maxsize=256)
+@functools.lru_cache(maxsize=16)
 def _get_etree_for_text(text):
     return etree.ElementTree(fromstring(text))
 


### PR DESCRIPTION
Changed the text saved to `Document.text` during parsing: Now, the flattened document text is saved, which resolves `xpath` issues that could come up during featurization, when using the original document.

Also added a method with `@functools.lru_cache` decorator to remove global caching dictionary and limit its size during structural featurization.