### PR TITLE
Add supporting functions for incrementally adding docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@
 Added
 ^^^^^
 
+* `@lukehsiao`_: Add supporting functions for incrementally adding documents.
+  (`#154 <https://github.com/HazyResearch/fonduer/pull/154>`_)
 * `@j-rausch`_: Added alpha spacy support for Japanese tokenizer.
 * `@senwu`_: Add sparse logistic regression support.
 * `@j-rausch`_: Added unit tests for changed lingual parsing pipeline.

--- a/src/fonduer/features/featurizer.py
+++ b/src/fonduer/features/featurizer.py
@@ -36,6 +36,31 @@ class Featurizer(UDFRunner):
         )
         self.candidate_classes = candidate_classes
 
+    def update(self, docs=None, split=0, parallelism=None, progress_bar=True):
+        """Update the labels of the specified candidates based on the provided LFs.
+
+        :param docs: If provided, apply features to all the candidates in these
+            documents.
+        :param split: If docs is None, apply features to the candidates in this
+            particular split.
+        :type split: int
+        :param parallelism: How many threads to use for extraction. This will
+            override the parallelism value used to initialize the Featurizer if
+            it is provided.
+        :type parallelism: int
+        :param progress_bar: Whether or not to display a progress bar. The
+            progress bar is measured per document.
+        :type progress_bar: bool
+        """
+        self.apply(
+            docs=docs,
+            split=split,
+            train=True,
+            clear=False,
+            parallelism=parallelism,
+            progress_bar=progress_bar,
+        )
+
     def apply(self, docs=None, split=0, train=False, clear=True, **kwargs):
         """Apply features to the specified candidates.
 

--- a/src/fonduer/features/featurizer.py
+++ b/src/fonduer/features/featurizer.py
@@ -37,7 +37,7 @@ class Featurizer(UDFRunner):
         self.candidate_classes = candidate_classes
 
     def update(self, docs=None, split=0, parallelism=None, progress_bar=True):
-        """Update the labels of the specified candidates based on the provided LFs.
+        """Update the features of the specified candidates.
 
         :param docs: If provided, apply features to all the candidates in these
             documents.

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -13,6 +13,7 @@ from fonduer.parser.models import (
     Caption,
     Cell,
     Context,
+    Document,
     Figure,
     Paragraph,
     Section,
@@ -79,7 +80,15 @@ class Parser(UDFRunner):
         )
 
     def clear(self, **kwargs):
+        """Clear all of the ``Context`` objects in the database."""
         self.session.query(Context).delete()
+
+    def get_documents(self):
+        """Return all the parsed ``Documents`` in the database.
+
+        :rtype: A generator for all ``Documents`` in the database.
+        """
+        return self.session.query(Document).order_by(Document.name).all()
 
 
 class ParserUDF(UDF):

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -195,10 +195,9 @@ class ParserUDF(UDF):
         # The document is the Document model
         text = document.text
 
-        # Use the provided pdf_path if present
-        self.pdf_path = pdf_path if pdf_path else self.pdf_path
-
         if self.visual:
+            # Use the provided pdf_path if present
+            self.pdf_path = pdf_path if pdf_path else self.pdf_path
             if not self.pdf_path:
                 warnings.warn(
                     "Visual parsing failed: pdf_path is required. "

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -79,14 +79,45 @@ class Parser(UDFRunner):
             language=language,
         )
 
-    def clear(self, **kwargs):
-        """Clear all of the ``Context`` objects in the database."""
+    def apply(
+        self, doc_loader, pdf_path=None, clear=True, parallelism=None, progress_bar=True
+    ):
+        """Run the Parser.
+
+        :param doc_loader: An iteratable of ``Documents`` to parse. Typically,
+            one of Fonduer's document preprocessors.
+        :param pdf_path: The path to the PDF documents, if any. This path will
+            override the one used in initialization, if provided.
+        :param clear: Whether or not to clear the labels table before applying
+            these LFs.
+        :type clear: bool
+        :param parallelism: How many threads to use for extraction. This will
+            override the parallelism value used to initialize the Labeler if
+            it is provided.
+        :type parallelism: int
+        :param progress_bar: Whether or not to display a progress bar. The
+            progress bar is measured per document.
+        :type progress_bar: bool
+        """
+        super(Parser, self).apply(
+            doc_loader,
+            pdf_path=pdf_path,
+            clear=clear,
+            parallelism=parallelism,
+            progress_bar=progress_bar,
+        )
+
+    def clear(self, pdf_path=None):
+        """Clear all of the ``Context`` objects in the database.
+
+        :param pdf_path: This parameter is ignored.
+        """
         self.session.query(Context).delete()
 
     def get_documents(self):
         """Return all the parsed ``Documents`` in the database.
 
-        :rtype: A generator for all ``Documents`` in the database.
+        :rtype: A list of all ``Documents`` in the database ordered by name.
         """
         return self.session.query(Document).order_by(Document.name).all()
 
@@ -160,9 +191,13 @@ class ParserUDF(UDF):
             self.pdf_path = pdf_path
             self.vizlink = VisualLinker()
 
-    def apply(self, document, **kwargs):
+    def apply(self, document, pdf_path=None, **kwargs):
         # The document is the Document model
         text = document.text
+
+        # Use the provided pdf_path if present
+        self.pdf_path = pdf_path if pdf_path else self.pdf_path
+
         if self.visual:
             if not self.pdf_path:
                 warnings.warn(

--- a/src/fonduer/utils/udf.py
+++ b/src/fonduer/utils/udf.py
@@ -82,9 +82,9 @@ class UDFRunner(object):
     def get_last_documents(self):
         """Return the last set of documents that was operated on with apply().
 
-        :rtype: set of ``Documents`` operated on in the last call to ``apply()``.
+        :rtype: list of ``Documents`` operated on in the last call to ``apply()``.
         """
-        return self.last_docs
+        return list(self.last_docs)
 
     def apply_st(self, doc_loader, **kwargs):
         """Run the UDF single-threaded, optionally with progress bar"""

--- a/src/fonduer/utils/udf.py
+++ b/src/fonduer/utils/udf.py
@@ -36,6 +36,9 @@ class UDFRunner(object):
         self.session = session
         self.parallelism = parallelism
 
+        #: The last set of documents that apply() was called on
+        self.last_docs = set()
+
     def apply(
         self, doc_loader, clear=True, parallelism=None, progress_bar=True, **kwargs
     ):
@@ -46,6 +49,9 @@ class UDFRunner(object):
         # Clear everything downstream of this UDF if requested
         if clear:
             self.clear(**kwargs)
+
+        # Clear the last operated documents
+        self.last_docs.clear()
 
         # Execute the UDF
         self.logger.info("Running UDF...")
@@ -73,12 +79,20 @@ class UDFRunner(object):
     def clear(self, **kwargs):
         raise NotImplementedError()
 
+    def get_last_documents(self):
+        """Return the last set of documents that was operated on with apply().
+
+        :rtype: set of ``Documents`` operated on in the last call to ``apply()``.
+        """
+        return self.last_docs
+
     def apply_st(self, doc_loader, **kwargs):
         """Run the UDF single-threaded, optionally with progress bar"""
         udf = self.udf_class(**self.udf_init_kwargs)
 
         # Run single-thread
         for doc in doc_loader:
+            self.last_docs.add(doc)
             if self.pb is not None:
                 self.pb.update(1)
 
@@ -94,6 +108,7 @@ class UDFRunner(object):
 
         def fill_input_queue(in_queue, doc_loader, terminal_signal):
             for doc in doc_loader:
+                self.last_docs.add(doc)
                 in_queue.put(doc)
             in_queue.put(terminal_signal)
 

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -85,8 +85,9 @@ def test_e2e(caplog):
     logger.info("Sentences: {}".format(num_sentences))
 
     # Divide into test and train
-    docs = session.query(Document).order_by(Document.name).all()
+    docs = corpus_parser.get_documents()
     ld = len(docs)
+    assert ld == len(corpus_parser.get_last_documents())
     assert len(docs[0].sentences) == 799
     assert len(docs[1].sentences) == 663
     assert len(docs[2].sentences) == 784

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -47,6 +47,148 @@ DB = "e2e_test"
 
 
 @pytest.mark.skipif("CI" not in os.environ, reason="Only run e2e on Travis")
+def test_incremental(caplog):
+    """Run an end-to-end test on incremental additions."""
+    caplog.set_level(logging.INFO)
+    # SpaCy on mac has issue on parallel parsing
+    if os.name == "posix":
+        logger.info("Using single core.")
+        PARALLEL = 1
+    else:
+        PARALLEL = 2  # Travis only gives 2 cores
+
+    max_docs = 1
+
+    session = Meta.init("postgres://localhost:5432/" + DB).Session()
+
+    docs_path = "tests/data/html/dtc114w.html"
+    pdf_path = "tests/data/pdf/dtc114w.pdf"
+
+    doc_preprocessor = HTMLDocPreprocessor(docs_path, max_docs=max_docs)
+
+    corpus_parser = Parser(
+        session,
+        parallelism=PARALLEL,
+        structural=True,
+        lingual=True,
+        visual=True,
+        pdf_path=pdf_path,
+    )
+    corpus_parser.apply(doc_preprocessor)
+
+    num_docs = session.query(Document).count()
+    logger.info("Docs: {}".format(num_docs))
+    assert num_docs == max_docs
+
+    docs = corpus_parser.get_documents()
+
+    # Mention Extraction
+    part_ngrams = MentionNgramsPart(parts_by_doc=None, n_max=3)
+    temp_ngrams = MentionNgramsTemp(n_max=2)
+
+    Part = mention_subclass("Part")
+    Temp = mention_subclass("Temp")
+
+    mention_extractor = MentionExtractor(
+        session, [Part, Temp], [part_ngrams, temp_ngrams], [part_matcher, temp_matcher]
+    )
+
+    mention_extractor.apply(docs, parallelism=PARALLEL)
+
+    assert session.query(Part).count() == 11
+    assert session.query(Temp).count() == 9
+
+    # Candidate Extraction
+    PartTemp = candidate_subclass("PartTemp", [Part, Temp])
+
+    candidate_extractor = CandidateExtractor(
+        session, [PartTemp], throttlers=[temp_throttler]
+    )
+
+    candidate_extractor.apply(docs, split=0, parallelism=PARALLEL)
+
+    assert session.query(PartTemp).filter(PartTemp.split == 0).count() == 78
+
+    # Grab candidate lists
+    train_cands = candidate_extractor.get_candidates(split=0)
+    assert len(train_cands) == 1
+    assert len(train_cands[0]) == 78
+
+    # Featurization
+    featurizer = Featurizer(session, [PartTemp])
+
+    featurizer.apply(split=0, train=True, parallelism=PARALLEL)
+    assert session.query(Feature).count() == 78
+    assert session.query(FeatureKey).count() == 496
+    F_train = featurizer.get_feature_matrices(train_cands)
+    assert F_train[0].shape == (78, 496)
+    assert len(featurizer.get_keys()) == 496
+
+    stg_temp_lfs = [
+        LF_storage_row,
+        LF_operating_row,
+        LF_temperature_row,
+        LF_tstg_row,
+        LF_to_left,
+        LF_negative_number_left,
+    ]
+
+    labeler = Labeler(session, [PartTemp])
+
+    labeler.apply(split=0, lfs=[stg_temp_lfs], train=True, parallelism=PARALLEL)
+    assert session.query(Label).count() == 78
+
+    # Only 5 because LF_operating_row doesn't apply to the first test doc
+    assert session.query(LabelKey).count() == 5
+    L_train = labeler.get_label_matrices(train_cands)
+    assert L_train[0].shape == (78, 5)
+    assert len(labeler.get_keys()) == 5
+
+    docs_path = "tests/data/html/112823.html"
+    pdf_path = "tests/data/pdf/112823.pdf"
+
+    doc_preprocessor = HTMLDocPreprocessor(docs_path, max_docs=max_docs)
+
+    corpus_parser.apply(doc_preprocessor, pdf_path=pdf_path, clear=False)
+
+    assert len(corpus_parser.get_documents()) == 2
+
+    new_docs = corpus_parser.get_last_documents()
+
+    assert len(new_docs) == 1
+    assert new_docs[0].name == "112823"
+
+    # Get mentions from just the new docs
+    mention_extractor.apply(new_docs, parallelism=PARALLEL, clear=False)
+
+    assert session.query(Part).count() == 81
+    assert session.query(Temp).count() == 27
+
+    # Just run candidate extraction and assign to split 0
+    candidate_extractor.apply(new_docs, split=0, parallelism=PARALLEL, clear=False)
+
+    # Grab candidate lists
+    train_cands = candidate_extractor.get_candidates(split=0)
+    assert len(train_cands) == 1
+    assert len(train_cands[0]) == 1256
+
+    # Update features
+    featurizer.update(new_docs, parallelism=PARALLEL)
+    assert session.query(Feature).count() == 1256
+    assert session.query(FeatureKey).count() == 2295
+    F_train = featurizer.get_feature_matrices(train_cands)
+    assert F_train[0].shape == (1256, 2295)
+    assert len(featurizer.get_keys()) == 2295
+
+    # Update Labels
+    labeler.update(new_docs, lfs=[stg_temp_lfs], parallelism=PARALLEL)
+    assert session.query(Label).count() == 1256
+    assert session.query(LabelKey).count() == 6
+    L_train = labeler.get_label_matrices(train_cands)
+    assert L_train[0].shape == (1256, 6)
+
+
+@pytest.mark.skipif("CI" not in os.environ, reason="Only run e2e on Travis")
 def test_e2e(caplog):
     """Run an end-to-end test on documents of the hardware domain."""
     caplog.set_level(logging.INFO)
@@ -232,7 +374,7 @@ def test_e2e(caplog):
     assert session.query(FeatureKey).count() == 675
     session.query(Feature).delete()
 
-    featurizer.apply(split=0, train=True, parallelism=1)
+    featurizer.apply(split=0, train=True, parallelism=PARALLEL)
     assert session.query(Feature).count() == 3346
     assert session.query(FeatureKey).count() == 3578
     F_train = featurizer.get_feature_matrices(train_cands)

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -16,7 +16,7 @@ def get_parser_udf(
     language="en",
     lingual=True,  # lingual information
     strip=True,
-    replacements=[(u"[\u2010\u2011\u2012\u2013\u2014\u2212\uf02d]", "-")],
+    replacements=[(u"[\u2010\u2011\u2012\u2013\u2014\u2212]", "-")],
     tabular=True,  # tabular information
     visual=False,  # visual information
     pdf_path=None,


### PR DESCRIPTION
The purpose of this PR is to allow users to incrementally add new documents, without rerunning the whole pipeline.

### Example Workflow

Assuming you already parsed a set of Documents, A, and wanted to add a new set of Documents, B, a user could now run something like the following, in the context of the [e2e test](https://github.com/HazyResearch/fonduer/blob/master/tests/e2e/test_e2e.py).

```py
    docs_path = "new_data/html/"
    pdf_path = "new_data/pdf/"

    doc_preprocessor = HTMLDocPreprocessor(docs_path, max_docs=max_docs)

    corpus_parser.apply(doc_preprocessor, pdf_path=pdf_path, clear=False)

    new_docs = corpus_parser.get_last_documents()

    # Get mentions from just the new docs
    mention_extractor.apply(new_docs, parallelism=PARALLEL, clear=False)

    # Just run candidate extraction and assign to split 0
    candidate_extractor.apply(new_docs, split=0, parallelism=PARALLEL, clear=False)

    # Update features
    featurizer.update(new_docs, parallelism=PARALLEL)

    # Update Labels
    labeler.update(new_docs, lfs=[stg_temp_lfs], parallelism=PARALLEL)
```