### PR TITLE
GenerativeModel was succeeded by LabelModel from metal.label_model

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -193,7 +193,8 @@ Fixed
         )
         from fonduer.candidates.models import candidate_subclass, mention_subclass
         from fonduer.features import Featurizer
-        from fonduer.learning import GenerativeModel, SparseLogisticRegression
+        from metal.label_model import LabelModel # GenerativeModel in v0.2.3
+        from fonduer.learning import SparseLogisticRegression
         from fonduer.parser import Parser
         from fonduer.parser.models import Document, Sentence
         from fonduer.parser.preprocessors import HTMLDocPreprocessor


### PR DESCRIPTION
Update the CHANGELOG.
As far as I found, e95930ff replaced `GenerativeModel` with `LabelLearner`; and 4665d4e replaced `LabelLearner` with `LabelModel from metal.label_model`.