### PR TITLE
Batch queries so that string buffer isn't exceeded

### DIFF
--- a/src/fonduer/utils/utils_udf.py
+++ b/src/fonduer/utils/utils_udf.py
@@ -56,18 +56,17 @@ def _batch_postgres_query(table, records):
         + ", ".join(["?"] * len(records[0].keys()))
         + ")\n"
     )
-    logger.warning(preamble)
     start = 0
     end = 0
     total_len = len(preamble)
     while end < len(records):
-        record_len = sum([len(v) for v in records[end].values()])
+        record_len = sum([len(str(v)) for v in records[end].values()])
 
         # Pre-increment to include the end element in the slice
         end += 1
 
         if total_len + record_len >= POSTGRESQL_MAX:
-            logger.warning("Splitting query due to length.")
+            logger.debug("Splitting query due to length ({} chars).".format(total_len))
             yield records[start:end]
             start = end
             # Reset the total query length


### PR DESCRIPTION
PostgreSQL queries have a limited buffer of 0x3fffffff (1GB - 1), which
means that giant queries cause an out of memory error [[1]].

In addition, this switches to the executemany syntax to reduce the
wasted space in the query string that comes with using .values().

[1]: https://dba.stackexchange.com/questions/131399/is-there-a-maximum-length-constraint-for-a-postgres-query