### PR TITLE
Modified get_row_ngrams and get_col_ngrams to return None for non-table mentions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ Changed
 ^^^^^^^
 * `@lukehsiao`_: Add soft version pinning to avoid failures due to dependency
   API changes.
+* `@j-rausch`_: Change ``get_row_ngrams`` and ``get_col_ngrams`` to return ``None``
+  if the passed ``Mention`` argument is not inside a table.
+  (`#194 <https://github.com/HazyResearch/fonduer/pull/194>`_)
 
 
 [0.4.0] - 2018-11-27

--- a/src/fonduer/utils/data_model_utils/tabular.py
+++ b/src/fonduer/utils/data_model_utils/tabular.py
@@ -135,6 +135,20 @@ def get_min_col_num(mention):
         return None
 
 
+def get_min_row_num(mention):
+    """Return the lowest row number that a Mention occupies.
+
+    :param mention: The Mention to evaluate. If a candidate is given, default
+        to its first Mention.
+    :rtype: integer or None
+    """
+    span = _to_span(mention)
+    if span.sentence.is_tabular():
+        return span.sentence.cell.row_start
+    else:
+        return None
+
+
 def get_sentence_ngrams(mention, attrib="words", n_min=1, n_max=1, lower=True):
     """Get the ngrams that are in the Sentence of the given Mention, not including itself.
 
@@ -425,6 +439,11 @@ def _get_axis_ngrams(
     mention, axis, attrib="words", n_min=1, n_max=1, spread=[0, 0], lower=True
 ):
     span = _to_span(mention)
+
+    if not span.sentence.is_tabular():
+        yield None
+        return
+
     for ngram in get_sentence_ngrams(
         span, attrib=attrib, n_min=n_min, n_max=n_max, lower=lower
     ):


### PR DESCRIPTION
I changed the behavior of `get_row_ngrams` and `get_col_ngrams` to return `None`, if a non-table mention is passed (see #186).
I chose `None`, as `[]` can be a valid return value at the moment, e.g. if all other cells in the row of a  `Mention` are empty.

Note that the current implementation of both functions also work on _candidates_, which will result in a list of ngrams being returned, even if only one of them is inside a table.