### PR TITLE
Fix `get_last_documents` to return valid Document objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Added
 
         max_docs = 10
 
-        # Define specific parser for the third column (index 2), which takes ``text``, 
+        # Define specific parser for the third column (index 2), which takes ``text``,
         # ``name=None``, ``type="text"``, and ``delim=None`` as input and generate
         # ``(content type, content name, content)`` for ``build_node``
         # in ``fonduer.utils.utils_parser``.
@@ -46,6 +46,9 @@ Added
 Fixed
 ^^^^^
 * `@HiromuHota`_: Modify docstring of functions that return get_sparse_matrix
+* `@lukehsiao`_: Fix the behavior of ``get_last_documents`` to return Documents
+  that are correctly linked to the database and can be navigated by the user.
+  (`#201 <https://github.com/HazyResearch/fonduer/pull/201>`_)
 
 Changed
 ^^^^^^^

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -117,6 +117,18 @@ class Parser(UDFRunner):
         """
         self.session.query(Context).delete()
 
+    def get_last_documents(self):
+        """Return the most recently parsed list of ``Documents``.
+
+        :rtype: A list of the most recently parsed ``Documents`` ordered by name.
+        """
+        return (
+            self.session.query(Document)
+            .filter(Document.name.in_(self.last_docs))
+            .order_by(Document.name)
+            .all()
+        )
+
     def get_documents(self):
         """Return all the parsed ``Documents`` in the database.
 

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -90,6 +90,9 @@ def test_incremental(caplog):
     assert num_docs == max_docs
 
     docs = corpus_parser.get_documents()
+    last_docs = corpus_parser.get_documents()
+
+    assert len(docs[0].sentences) == len(last_docs[0].sentences)
 
     # Mention Extraction
     part_ngrams = MentionNgramsPart(parts_by_doc=None, n_max=3)
@@ -242,9 +245,13 @@ def test_e2e(caplog):
     logger.info("Sentences: {}".format(num_sentences))
 
     # Divide into test and train
-    docs = corpus_parser.get_documents()
+    docs = sorted(corpus_parser.get_documents())
+    last_docs = sorted(corpus_parser.get_last_documents())
+
     ld = len(docs)
-    assert ld == len(corpus_parser.get_last_documents())
+    assert ld == len(last_docs)
+    assert len(docs[0].sentences) == len(last_docs[0].sentences)
+
     assert len(docs[0].sentences) == 799
     assert len(docs[1].sentences) == 663
     assert len(docs[2].sentences) == 784


### PR DESCRIPTION
The previous implementation would track the last parsed documents using
a set of Document objects returned by a Preprocesser. Thus, when a user
called `get_last_documents`, they would get Documents, but not Documents
which had any linkage to the underlying database, and thus could not
view the document's ID, or relationships like Sentences.

This commit is twofold. First, we move the `get_last_documents` call
implementation to the Parser, rather than having it in the UDF. This
just makes more organizational sense. Second, it queries the database
for Documents by filtering on the names of the last documents, ensuring
that the returned documents can be navigated by the user (e.g., to view
the Sentences).