### PR TITLE
Fix installation instructions

### DIFF
--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -20,7 +20,8 @@ For OS X using homebrew_::
 On Debian-based distros::
 
     $ sudo apt update
-    $ sudo apt install libxml2-dev libxslt-dev python3-dev build-dep python-matplotlib
+    $ sudo apt install libxml2-dev libxslt-dev python3-dev 
+    $ sudo apt build-dep python-matplotlib
     $ sudo apt install poppler-utils
     $ sudo apt install postgresql
 


### PR DESCRIPTION
Change:
`sudo apt install libxml2-dev libxslt-dev python3-dev build-dep python-matplotlib`
To:
`sudo apt install libxml2-dev libxslt-dev python3-dev`
`sudo apt build-dep python-matplotlib`