### PR TITLE
fix max/min in visualizer.get_box

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -611,3 +611,4 @@ Minor hotfix to the README formatting for PyPi.
 .. _@prabh06: https://github.com/Prabh06
 .. _@HiromuHota: https://github.com/HiromuHota
 .. _@j-rausch: https://github.com/j-rausch
+.. _@KenSugimoto: https://github.com/KenSugimoto

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Fixed
 * `@HiromuHota`_: Specify pytorch version as 0.4.1.post2 to safeguard from HazyResearch/metal#101
 * `@lukehsiao`_: Update PyYAML dependency to patch CVE-2017-18342.
   (`#205 <https://github.com/HazyResearch/fonduer/pull/205>`_)
+* `@KenSugimoto`_: Fix max/min in ``visualizer.get_box``
 
 [0.5.0] - 2019-01-01
 --------------------

--- a/src/fonduer/utils/visualizer.py
+++ b/src/fonduer/utils/visualizer.py
@@ -94,8 +94,8 @@ def get_box(span):
     box = (
         min(span.get_attrib_tokens("page")),
         min(span.get_attrib_tokens("top")),
-        max(span.get_attrib_tokens("left")),
-        min(span.get_attrib_tokens("bottom")),
+        min(span.get_attrib_tokens("left")),
+        max(span.get_attrib_tokens("bottom")),
         max(span.get_attrib_tokens("right")),
     )
     return box


### PR DESCRIPTION
The bounding box value increases from left to right and from top to bottom, so I think the left bounding box value of the span should be "min" of words and the bottom should be "max" of words.