### PR TITLE
Store lemmas and pos_tags in case they are returned from a tokenizer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,7 @@ Changed
 
 Fixed
 ^^^^^
+* `@HiromuHota`_: Store lemmas and pos_tags in case they are returned from a tokenizer.
 * `@HiromuHota`_: Use unidic instead of ipadic for Japanese.
   (`#231 <https://github.com/HazyResearch/fonduer/issues/231>`_)
 * `@senwu`_: Use mecab-python3 version 0.7 for Japanese tokenization since

--- a/src/fonduer/parser/spacy_parser.py
+++ b/src/fonduer/parser/spacy_parser.py
@@ -300,8 +300,8 @@ class Spacy(object):
 
             for i, token in enumerate(sent):
                 parts["words"].append(str(token))
-                parts["lemmas"].append("")  # placeholder for later NLP parsing
-                parts["pos_tags"].append("")  # placeholder for later NLP parsing
+                parts["lemmas"].append(token.lemma_)
+                parts["pos_tags"].append(token.pos_)
                 parts["ner_tags"].append("")  # placeholder for later NLP parsing
                 parts["char_offsets"].append(token.idx)
                 parts["abs_char_offsets"].append(token.idx)

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -224,20 +224,32 @@ def test_spacy_japanese(caplog):
         pass
 
     assert len(doc.sentences) == 289
-    sent = doc.sentences[2]
-    assert sent.text == "出典:フリー百科事典『ウィキペディア（Wikipedia）』"
-    assert sent.words == [
-        "出典",
-        ":",
-        "フリー",
-        "百科",
-        "事典",
-        "『",
-        "ウィキペディア",
-        "（",
-        "Wikipedia",
-        "）",
-        "』",
+    sent = doc.sentences[42]
+    assert sent.text == "当時マルコ・ポーロが辿り着いたと言われる"
+    assert sent.words == ["当時", "マルコ", "・", "ポーロ", "が", "辿り着い", "た", "と", "言わ", "れる"]
+    assert sent.pos_tags == [
+        "NOUN",
+        "PROPN",
+        "SYM",
+        "PROPN",
+        "ADP",
+        "VERB",
+        "AUX",
+        "ADP",
+        "VERB",
+        "AUX",
+    ]
+    assert sent.lemmas == [
+        "当時",
+        "マルコ-Marco",
+        "・",
+        "ポーロ-Polo",
+        "が",
+        "辿り着く",
+        "た",
+        "と",
+        "言う",
+        "れる",
     ]
     # Japanese sentences are only tokenized.
     assert sent.ner_tags == [""] * len(sent.words)


### PR DESCRIPTION
The Japanese tokenizer returns lemmas and pos_tags.