### PR TITLE
Refactor TokenPreservingTokenizer for readability

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 [Unreleased]
 ------------
 
+Changed
+^^^^^^^
+* `@HiromuHota`_: Refactor TokenPreservingTokenizer for readability.
+
 [0.6.2] - 2019-04-01
 --------------------
 


### PR DESCRIPTION
1. `doc = custom_tokenizer()` is not quite easy to understand because `TokenPreservingTokenizer.__call__` has a different API from spaCy's `Tokenizer.__call__`, which takes a string as an input.
2. `all_input_tokens` and `all_spaces` should not be member variables. First time call `custom_tokenizer()` is fine, but the second time call returns an unexpected result.