### PR TITLE
Enable pip cache even when language: generic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: generic
 dist: xenial
-cache: pip
+cache:
+  directories:
+  - $HOME/.cache/pip
+before_cache:
+  - rm -f $HOME/.cache/pip/log/debug.log
 
 
 matrix:


### PR DESCRIPTION
According to [TravisCI](https://docs.travis-ci.com/user/caching/#caching-directories-bundler-dependencies), .travis.yml should use 
```
language: python
cache: pip
```
but the current .travis.yml uses `language: generic` and travis job log does not say anything about pip cache.

Hoping to re-enable pip caching, this patch specifies the cache directory manually instead of using caching shortcut (e.g., `cache: pip`).