### PR TITLE
Add a unit test for Parser with tabular=False and Associate sentence with section and paragraph no matter what tabular is

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -67,11 +67,15 @@ Changed
 * `@HiromuHota`_: Rename SimpleTokenizer into SimpleParser and let it inherit LingualParser.
 * `@HiromuHota`_: Move all ligual parsers into lingual_parser folder.
 * `@HiromuHota`_: Make load_lang_model private as a model is internally loaded during init.
+* `@HiromuHota`_: Add a unit test for ``Parser`` with tabular=False.
+  (`#261 <https://github.com/HazyResearch/fonduer/pull/261>`_)
 
 Fixed
 ^^^^^
 * `@senwu`_: Fix legacy code bug in ``SymbolTable``.
 * `@HiromuHota`_: Fix the type of max_docs.
+* `@HiromuHota`_: Associate sentence with section and paragraph no matter what tabular is.
+  (`#261 <https://github.com/HazyResearch/fonduer/pull/261>`_)
 
 [0.7.0] - 2019-06-12
 --------------------

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -543,24 +543,23 @@ class ParserUDF(UDF):
                                         ]
                                     )
                             break
-            if self.tabular:
-                parts["position"] = state["sentence"]["idx"]
+            parts["position"] = state["sentence"]["idx"]
 
-                # If tabular, consider own Context first in case a Cell
-                # was just created. Otherwise, defer to the parent.
-                parent = paragraph
-                if isinstance(parent, Paragraph):
-                    parts["section"] = parent.section
-                    parts["paragraph"] = parent
-                    if parent.cell:
-                        parts["table"] = parent.cell.table
-                        parts["cell"] = parent.cell
-                        parts["row_start"] = parent.cell.row_start
-                        parts["row_end"] = parent.cell.row_end
-                        parts["col_start"] = parent.cell.col_start
-                        parts["col_end"] = parent.cell.col_end
-                else:
-                    raise NotImplementedError("Sentence parent must be Paragraph.")
+            # If tabular, consider own Context first in case a Cell
+            # was just created. Otherwise, defer to the parent.
+            parent = paragraph
+            if isinstance(parent, Paragraph):
+                parts["section"] = parent.section
+                parts["paragraph"] = parent
+                if parent.cell:  # if True self.tabular is also always True
+                    parts["table"] = parent.cell.table
+                    parts["cell"] = parent.cell
+                    parts["row_start"] = parent.cell.row_start
+                    parts["row_end"] = parent.cell.row_end
+                    parts["col_start"] = parent.cell.col_start
+                    parts["col_end"] = parent.cell.col_end
+            else:
+                raise NotImplementedError("Sentence parent must be Paragraph.")
             yield Sentence(**parts)
             state["sentence"]["idx"] += 1
 

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -155,7 +155,6 @@ def test_parse_md_details(caplog):
 def test_parse_wo_tabular(caplog):
     """Test the parser without extracting tabular information."""
     caplog.set_level(logging.INFO)
-    logger = logging.getLogger(__name__)
 
     docs_path = "tests/data/html_simple/md.html"
     pdf_path = "tests/data/pdf_simple/md.pdf"
@@ -185,10 +184,11 @@ def test_parse_wo_tabular(caplog):
     assert len(doc.sentences) == 45
 
     # Check that sentences are associated with both section and paragraph.
-    sent = doc.sentences[0]
-    assert sent.section
-    assert sent.paragraph
-    logger.info(f"  {sent}")
+    assert all([sent.section is not None for sent in doc.sentences])
+    assert all([sent.paragraph is not None for sent in doc.sentences])
+
+    # Check that sentences are NOT associated with cell
+    assert all([sent.cell is None for sent in doc.sentences])
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This unit test fails because of `tabular=False`, which makes this PR sort of WIP.

Because of `tabular=False`, any `Sentence` are not associated with `Section` nor `Paragraph`.
Is this expected behavior?

Even this is an expected behavior, `str(sent)` should not fail but currently it fails because `sent` is not associated with section or paragraph.