### PR TITLE
Assign a section for mention spaces

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Added
 
 Changed
 ^^^^^^^
+* `@HiromuHota`_: Assign a section for mention spaces.
 * `@HiromuHota`_: Incorporate entity_confusion_matrix as a first-class citizen and rename it to confusion_matrix because it can be used both entity-level and mention-level.
 * `@HiromuHota`_: Separate Spacy#_split_sentences_by_char_limit to test itself.
 * `@HiromuHota`_: Refactor the custom sentence_boundary_detector for readability and efficiency.

--- a/docs/user/candidates.rst
+++ b/docs/user/candidates.rst
@@ -19,9 +19,53 @@ Core Objects
 
 These are Fonduer_'s core objects used for Mention and Candidate extraction.
 
-.. automodule:: fonduer.candidates
+.. autoclass:: fonduer.candidates.MentionExtractor
     :members:
     :inherited-members:
+    :show-inheritance:
+
+.. autoclass:: fonduer.candidates.CandidateExtractor
+    :members:
+    :inherited-members:
+    :show-inheritance:
+
+MentionSpaces
+-------------
+
+A *MentionSpace* defines a space where mentions lie on. You can use a pre-defined child
+class of MentionSpace or extend one depending on your needs.
+
+.. autoclass:: fonduer.candidates.mentions.MentionSpace
+    :show-inheritance:
+
+.. autoclass:: fonduer.candidates.mentions.Ngrams
+    :show-inheritance:
+
+.. autoclass:: fonduer.candidates.mentions.MentionNgrams
+    :show-inheritance:
+
+.. autoclass:: fonduer.candidates.mentions.MentionFigures
+    :show-inheritance:
+
+.. autoclass:: fonduer.candidates.mentions.MentionSentences
+    :show-inheritance:
+
+.. autoclass:: fonduer.candidates.mentions.MentionParagraphs
+    :show-inheritance:
+
+.. autoclass:: fonduer.candidates.mentions.MentionCaptions
+    :show-inheritance:
+
+.. autoclass:: fonduer.candidates.mentions.MentionCells
+    :show-inheritance:
+
+.. autoclass:: fonduer.candidates.mentions.MentionTables
+    :show-inheritance:
+
+.. autoclass:: fonduer.candidates.mentions.MentionSections
+    :show-inheritance:
+
+.. autoclass:: fonduer.candidates.mentions.MentionDocuments
     :show-inheritance:
 
 Matchers

--- a/docs/user/candidates.rst
+++ b/docs/user/candidates.rst
@@ -32,8 +32,9 @@ These are Fonduer_'s core objects used for Mention and Candidate extraction.
 MentionSpaces
 -------------
 
-A *MentionSpace* defines a space where mentions lie on. You can use a pre-defined child
-class of MentionSpace or extend one depending on your needs.
+A *MentionSpace* defines the space of mentions, i.e., the set of all possible mentions.
+Depending on your needs, you can use a pre-defined child class of MentionSpace or extend
+one.
 
 .. autoclass:: fonduer.candidates.mentions.MentionSpace
     :show-inheritance:


### PR DESCRIPTION
MentionSpaces are conceptually different from Mention/CandidateExtractor.
So it would be a good idea to assign a whole section for MentionSpaces like Matchers.