### PR TITLE
Clarify the effect of longest_match_only when used with Union, Intersect, or Inverse

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,6 +70,7 @@ Changed
 * `@HiromuHota`_: Make load_lang_model private as a model is internally loaded during init.
 * `@HiromuHota`_: Add a unit test for ``Parser`` with tabular=False.
   (`#261 <https://github.com/HazyResearch/fonduer/pull/261>`_)
+* `@HiromuHota`_: Now ``longest_match_only`` of ``Union``, ``Intersect``, and ``Inverse`` override that of child matchers.
 
 Removed
 ^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -78,6 +78,7 @@ Removed
 * `@HiromuHota`_: Remove __repr__ from each mixin class as the referenced attributes are not available.
 * `@HiromuHota`_: Remove the dependency on nltk, but ``PorterStemmer()`` can still be used,
   if it is provided as ``DictionaryMatch(stemmer=PorterStemmer())``.
+* `@HiromuHota`_: Remove ``_NgramMatcher`` and ``_FigureMatcher`` as they are no longer needed.
 
 Fixed
 ^^^^^

--- a/src/fonduer/candidates/matchers.py
+++ b/src/fonduer/candidates/matchers.py
@@ -226,12 +226,14 @@ class Inverse(_Matcher):
     :raises ValueError: If more than one Matcher is provided.
     """
 
-    # TODO: confirm that this only has one child
-    def f(self, m: TemporaryContext) -> bool:
-        if len(self.children) > 1:
+    def __init__(self, *children, **opts):  # type: ignore
+        if not len(children) == 1:
             raise ValueError("Provide a single Matcher.")
-        for child in self.children:
-            return not child.f(m)
+        super().__init__(*children, **opts)
+
+    def f(self, m: TemporaryContext) -> bool:
+        child = self.children[0]
+        return not child.f(m)
 
 
 class Concat(_NgramMatcher):

--- a/src/fonduer/candidates/matchers.py
+++ b/src/fonduer/candidates/matchers.py
@@ -159,6 +159,7 @@ class Union(_Matcher):
     """Takes the union of mention sets returned by the provided ``Matchers``.
 
     :param longest_match_only: If True, only return the longest match. Default True.
+        Overrides longest_match_only of its child matchers.
     :type longest_match_only: bool
     """
 
@@ -170,7 +171,12 @@ class Union(_Matcher):
 
 
 class Intersect(_Matcher):
-    """Takes the intersection of mention sets returned by the provided ``Matchers``."""
+    """Takes the intersection of mention sets returned by the provided ``Matchers``.
+
+    :param longest_match_only: If True, only return the longest match. Default True.
+        Overrides longest_match_only of its child matchers.
+    :type longest_match_only: bool
+    """
 
     def f(self, m: TemporaryContext) -> bool:
         for child in self.children:
@@ -183,6 +189,9 @@ class Inverse(_Matcher):
     """Returns the opposite result of ifs child ``Matcher``.
 
     :raises ValueError: If more than one Matcher is provided.
+    :param longest_match_only: If True, only return the longest match. Default True.
+        Overrides longest_match_only of its child matchers.
+    :type longest_match_only: bool
     """
 
     def __init__(self, *children, **opts):  # type: ignore
@@ -317,8 +326,8 @@ class RegexMatchSpan(_RegexMatch):
         Default True.
     :type full_match: bool
     :param longest_match_only: If True, only return the longest match. Default True.
-        Ignored when used as a child matcher of :class:`Union`, :class:`Intersect`,
-        or :class:`Inverse`.
+        Will be overridden by the parent matcher like :class:`Union` when it is wrapped
+        by :class:`Union`, :class:`Intersect`, or :class:`Inverse`.
     :type longest_match_only: bool
     """
 

--- a/src/fonduer/candidates/matchers.py
+++ b/src/fonduer/candidates/matchers.py
@@ -197,7 +197,11 @@ class LambdaFunctionMatcher(_NgramMatcher):
 
 
 class Union(_NgramMatcher):
-    """Takes the union of mention sets returned by the provided ``Matchers``."""
+    """Takes the union of mention sets returned by the provided ``Matchers``.
+
+    :param longest_match_only: If True, only return the longest match. Default True.
+    :type longest_match_only: bool
+    """
 
     def f(self, m: TemporaryContext) -> bool:
         for child in self.children:
@@ -351,8 +355,8 @@ class RegexMatchSpan(_RegexMatch):
     :param full_match: If True, wrap the provided rgx with ``(<rgx>)$``.
         Default True.
     :type full_match: bool
-    :param longest_match_only: If True, only return the longest match. Default
-        True.
+    :param longest_match_only: If True, only return the longest match. Default True.
+        Ignored when used as a child matcher of :class:`Union`.
     :type longest_match_only: bool
     """
 

--- a/src/fonduer/candidates/matchers.py
+++ b/src/fonduer/candidates/matchers.py
@@ -159,7 +159,7 @@ class Union(_Matcher):
     """Takes the union of mention sets returned by the provided ``Matchers``.
 
     :param longest_match_only: If True, only return the longest match. Default True.
-        Overrides longest_match_only of its child matchers.
+        Overrides longest_match_only of its child ``Matchers``.
     :type longest_match_only: bool
     """
 
@@ -174,7 +174,7 @@ class Intersect(_Matcher):
     """Takes the intersection of mention sets returned by the provided ``Matchers``.
 
     :param longest_match_only: If True, only return the longest match. Default True.
-        Overrides longest_match_only of its child matchers.
+        Overrides longest_match_only of its child ``Matchers``.
     :type longest_match_only: bool
     """
 
@@ -190,7 +190,7 @@ class Inverse(_Matcher):
 
     :raises ValueError: If more than one Matcher is provided.
     :param longest_match_only: If True, only return the longest match. Default True.
-        Overrides longest_match_only of its child matchers.
+        Overrides longest_match_only of its child ``Matchers``.
     :type longest_match_only: bool
     """
 

--- a/src/fonduer/candidates/matchers.py
+++ b/src/fonduer/candidates/matchers.py
@@ -356,7 +356,8 @@ class RegexMatchSpan(_RegexMatch):
         Default True.
     :type full_match: bool
     :param longest_match_only: If True, only return the longest match. Default True.
-        Ignored when used as a child matcher of :class:`Union`.
+        Ignored when used as a child matcher of :class:`Union`, :class:`Intersect`,
+        or :class:`Inverse`.
     :type longest_match_only: bool
     """
 

--- a/src/fonduer/candidates/matchers.py
+++ b/src/fonduer/candidates/matchers.py
@@ -69,11 +69,7 @@ class _Matcher(object):
                 yield m
 
 
-class _NgramMatcher(_Matcher):
-    """Matcher base class for Ngram objects"""
-
-
-class DictionaryMatch(_NgramMatcher):
+class DictionaryMatch(_Matcher):
     """Selects mention Ngrams that match against a given list *d*.
 
     :param d: A list of strings representing a dictionary.
@@ -123,7 +119,7 @@ class DictionaryMatch(_NgramMatcher):
         return (not self.inverse) if p in self.d else self.inverse
 
 
-class LambdaFunctionMatcher(_NgramMatcher):
+class LambdaFunctionMatcher(_Matcher):
     """Selects Ngrams that return True when fed to a function f.
 
     :param func: The function to evaluate with a signature of ``f: m -> {True, False}``,
@@ -204,7 +200,7 @@ class Inverse(_Matcher):
         return not child.f(m)
 
 
-class Concat(_NgramMatcher):
+class Concat(_Matcher):
     """Selects mentions which are the concatenation of adjacent matches from
     child operators.
 
@@ -272,7 +268,7 @@ class Concat(_NgramMatcher):
         return False
 
 
-class _RegexMatch(_NgramMatcher):
+class _RegexMatch(_Matcher):
     """
     Base regex class. Does not specify specific semantics of *what* is being
     matched yet.
@@ -465,11 +461,7 @@ class MiscMatcher(RegexMatchEach):
         super(MiscMatcher, self).__init__(*children, **kwargs)
 
 
-class _FigureMatcher(_Matcher):
-    """Matcher base class for Figure objects"""
-
-
-class LambdaFunctionFigureMatcher(_FigureMatcher):
+class LambdaFunctionFigureMatcher(_Matcher):
     """Selects Figures that return True when fed to a function f.
 
     :param func: The function to evaluate. See :class:`LambdaFunctionMatcher` for

--- a/tests/candidates/test_matchers.py
+++ b/tests/candidates/test_matchers.py
@@ -1,0 +1,172 @@
+import pytest
+
+from fonduer.candidates.matchers import Intersect, Inverse, RegexMatchSpan, Union
+from fonduer.candidates.mentions import MentionNgrams
+from fonduer.candidates.models.span_mention import TemporarySpanMention
+from fonduer.parser.lingual_parser.spacy_parser import SpacyParser
+from fonduer.parser.models import Document, Sentence
+
+
+@pytest.fixture()
+def doc_setup():
+    doc = Document(id=1, name="test", stable_id="1::document:0:0")
+    doc.text = "This is apple"
+    lingual_parser = SpacyParser("en")
+    for parts in lingual_parser.split_sentences(doc.text):
+        parts["document"] = doc
+        Sentence(**parts)
+    return doc
+
+
+def test_union(caplog, doc_setup):
+    doc = doc_setup
+    space = MentionNgrams(n_min=1, n_max=2)
+    tc: TemporarySpanMention
+    assert set(tc.get_span() for tc in space.apply(doc)) == {
+        "This is",
+        "is apple",
+        "This",
+        "is",
+        "apple",
+    }
+
+    # Match any span that contains "apple"
+    matcher0 = RegexMatchSpan(
+        rgx=r"apple", search=True, full_match=True, longest_match_only=False
+    )
+    assert set(tc.get_span() for tc in matcher0.apply(space.apply(doc))) == {
+        "is apple",
+        "apple",
+    }
+
+    # Match any span that contains "this" (case insensitive)
+    matcher1 = RegexMatchSpan(
+        rgx=r"this", search=False, full_match=False, longest_match_only=False
+    )
+    assert set(tc.get_span() for tc in matcher1.apply(space.apply(doc))) == {
+        "This is",
+        "This",
+    }
+
+    matcher = Union(matcher0, matcher1, longest_match_only=False)
+    assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {
+        "is apple",
+        "apple",
+        "This is",
+        "This",
+    }
+
+    # longest_match_only of each matcher is ignored.
+    matcher = Union(matcher0, matcher1, longest_match_only=True)
+    assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {
+        "This is",
+        "is apple",
+    }
+
+
+def test_intersect(caplog, doc_setup):
+    doc = doc_setup
+    space = MentionNgrams(n_min=1, n_max=3)
+    tc: TemporarySpanMention
+
+    # Match any span that contains "apple"
+    matcher0 = RegexMatchSpan(
+        rgx=r"apple", search=True, full_match=True, longest_match_only=False
+    )
+    assert set(tc.get_span() for tc in matcher0.apply(space.apply(doc))) == {
+        "This is apple",
+        "is apple",
+        "apple",
+    }
+
+    # Match any span that contains "this" (case insensitive)
+    matcher1 = RegexMatchSpan(
+        rgx=r"this", search=False, full_match=False, longest_match_only=False
+    )
+    assert set(tc.get_span() for tc in matcher1.apply(space.apply(doc))) == {
+        "This is apple",
+        "This is",
+        "This",
+    }
+
+    # Intersection of matcher0 and matcher1
+    matcher = Intersect(matcher0, matcher1, longest_match_only=False)
+    assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {
+        "This is apple"
+    }
+
+    # Intersection of matcher0 and matcher0
+    matcher = Intersect(matcher0, matcher0, longest_match_only=False)
+    assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {
+        "This is apple",
+        "is apple",
+        "apple",
+    }
+
+    # longest_match_only=True has no effect on Intersect.
+    matcher = Intersect(matcher0, matcher0, longest_match_only=True)
+    assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {
+        "This is apple",
+        "is apple",
+        "apple",
+    }
+
+
+def test_inverse(caplog, doc_setup):
+    doc = doc_setup
+    space = MentionNgrams(n_min=1, n_max=2)
+    tc: TemporarySpanMention
+    assert set(tc.get_span() for tc in space.apply(doc)) == {
+        "This is",
+        "is apple",
+        "This",
+        "is",
+        "apple",
+    }
+
+    # Match any span that contains "apple" with longest_match_only=False
+    matcher0 = RegexMatchSpan(
+        rgx=r"apple", search=True, full_match=True, longest_match_only=False
+    )
+    assert set(tc.get_span() for tc in matcher0.apply(space.apply(doc))) == {
+        "is apple",
+        "apple",
+    }
+
+    # Take an inverse
+    matcher = Inverse(matcher0, longest_match_only=False)
+    assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {
+        "This is",
+        "This",
+        "is",
+    }
+
+    # longest_match_only=True has no effect on Inverse.
+    matcher = Inverse(matcher0, longest_match_only=True)
+    assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {
+        "This is",
+        "This",
+        "is",
+    }
+
+    # Match any span that contains "apple" with longest_match_only=True
+    matcher0 = RegexMatchSpan(
+        rgx=r"apple", search=True, full_match=True, longest_match_only=True
+    )
+    assert set(tc.get_span() for tc in matcher0.apply(space.apply(doc))) == {"is apple"}
+
+    # longest_match_only=False on Inverse is in effect.
+    matcher = Inverse(matcher0, longest_match_only=False)
+    assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {
+        "This is",
+        "This",
+        "is",
+    }
+
+    # longest_match_only=True has no effect on Inverse.
+    matcher = Inverse(matcher0, longest_match_only=True)
+    assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {
+        "This is",
+        "This",
+        "is",
+    }

--- a/tests/candidates/test_matchers.py
+++ b/tests/candidates/test_matchers.py
@@ -170,3 +170,11 @@ def test_inverse(caplog, doc_setup):
         "This",
         "is",
     }
+
+    # Check if Inverse raises an error when no child matcher is provided.
+    with pytest.raises(ValueError):
+        Inverse()
+
+    # Check if Inverse raises an error when two child matchers are provided.
+    with pytest.raises(ValueError):
+        Inverse(matcher0, matcher0)

--- a/tests/candidates/test_matchers.py
+++ b/tests/candidates/test_matchers.py
@@ -103,7 +103,7 @@ def test_intersect(caplog, doc_setup):
         "apple",
     }
 
-    # longest_match_only=True has no effect on Intersect.
+    # longest_match_only=True overrides that of child matchers.
     matcher = Intersect(matcher0, matcher0, longest_match_only=True)
     assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {
         "This is apple"
@@ -157,7 +157,7 @@ def test_inverse(caplog, doc_setup):
         "is",
     }
 
-    # longest_match_only=True has no effect on Inverse.
+    # longest_match_only=True on Inverse is in effect.
     matcher = Inverse(matcher0, longest_match_only=True)
     assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {"This is"}
 

--- a/tests/candidates/test_matchers.py
+++ b/tests/candidates/test_matchers.py
@@ -106,9 +106,7 @@ def test_intersect(caplog, doc_setup):
     # longest_match_only=True has no effect on Intersect.
     matcher = Intersect(matcher0, matcher0, longest_match_only=True)
     assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {
-        "This is apple",
-        "is apple",
-        "apple",
+        "This is apple"
     }
 
 
@@ -141,13 +139,9 @@ def test_inverse(caplog, doc_setup):
         "is",
     }
 
-    # longest_match_only=True has no effect on Inverse.
+    # longest_match_only=True
     matcher = Inverse(matcher0, longest_match_only=True)
-    assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {
-        "This is",
-        "This",
-        "is",
-    }
+    assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {"This is"}
 
     # Match any span that contains "apple" with longest_match_only=True
     matcher0 = RegexMatchSpan(
@@ -165,11 +159,7 @@ def test_inverse(caplog, doc_setup):
 
     # longest_match_only=True has no effect on Inverse.
     matcher = Inverse(matcher0, longest_match_only=True)
-    assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {
-        "This is",
-        "This",
-        "is",
-    }
+    assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {"This is"}
 
     # Check if Inverse raises an error when no child matcher is provided.
     with pytest.raises(ValueError):


### PR DESCRIPTION
I realized that `longest_match_only` of a child matcher is ignored when used with `Union`.
If you want to disable `longest_match_only`, you have to add `longest_match_only=False` to `Union` instead of an individual matcher.

This is true for other matcher operators like `Inverse` and `Intersect` too, but I'm not sure how this affects the result.
@SenWu, @lukehsiao, any thoughts?