### PR TITLE
Remove the default value "<NB>" from delim of SimpleTokenizer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -99,6 +99,8 @@ Changed
   (`#306 <https://github.com/HazyResearch/fonduer/issues/306>`_)
 * `@HiromuHota`_: Pin PyTorch on 1.1.0 to align with Snorkel of 0.9.X.
 * `@HiromuHota`_: Depend on psycopg2 instead of psycopg2-binary as the latter is not recommended for production.
+* `@HiromuHota`_: Change the default value for ``delim`` of ``SimpleParser`` from "<NB>" to ".".
+  (`#272 <https://github.com/HazyResearch/fonduer/pull/272>`_)
 
 Removed
 ^^^^^^^

--- a/src/fonduer/parser/lingual_parser/simple_parser.py
+++ b/src/fonduer/parser/lingual_parser/simple_parser.py
@@ -7,9 +7,13 @@ from fonduer.parser.lingual_parser.lingual_parser import LingualParser
 
 
 class SimpleParser(LingualParser):
-    """Tokenizes text on whitespace only using split()."""
+    """Tokenizes text on whitespace only using split().
 
-    def __init__(self, delim: str = "<NB>") -> None:
+    :param delim: a delimiter to split text into sentences.
+    :type delim: str
+    """
+
+    def __init__(self, delim: str = ".") -> None:
         self.delim = delim
 
     def split_sentences(self, str: str) -> Iterator[Dict[str, Any]]:

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -5,7 +5,7 @@ import pytest
 
 from fonduer.parser.lingual_parser import SpacyParser
 from fonduer.parser.models import Document
-from fonduer.parser.parser import ParserUDF
+from fonduer.parser.parser import ParserUDF, SimpleParser
 from fonduer.parser.preprocessors import (
     CSVDocPreprocessor,
     HTMLDocPreprocessor,
@@ -458,7 +458,11 @@ def test_simple_parser():
 
     # Create an Parser and parse the md document
     parser_udf = get_parser_udf(
-        structural=True, lingual=False, visual=True, pdf_path=pdf_path, language=None
+        structural=True,
+        lingual=False,
+        visual=True,
+        pdf_path=pdf_path,
+        lingual_parser=SimpleParser(delim="NoDelim"),
     )
     for _ in parser_udf.apply(doc):
         pass

--- a/tests/parser/test_simple_parser.py
+++ b/tests/parser/test_simple_parser.py
@@ -9,7 +9,7 @@ def test_simple_parser_support():
 
 def test_simple_split_sentences():
     tokenize_and_split_sentences = SimpleParser().split_sentences
-    text = "This is a text.<NB>This is another text."
+    text = "This is a text. This is another text."
 
     iterator = tokenize_and_split_sentences(text)
     assert len(list(iterator)) == 2


### PR DESCRIPTION
Removing the default value "\<NB\>", which used to be used for Stanford CoreNLP.
Because Fonduer now mainly uses spaCy instead of Stanford CoreNLP, "\<NB\>" should not be the default.
You can still specify delim="\<NB\>" if they need it.