### PR TITLE
Make Visualizer#display_candidates mention-type argnostic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -129,6 +129,7 @@ Fixed
 * `@HiromuHota`_: Fix the issue that Labeler.apply with docs instead of split fails.
   (`#340 <https://github.com/HazyResearch/fonduer/pull/340>`_)
 * `@HiromuHota`_: Make mention/candidate_subclasses and their objects picklable.
+* `@HiromuHota`_: Make Visualizer#display_candidates mention-type argnostic.
 
 0.7.0_ - 2019-06-12
 -------------------

--- a/src/fonduer/utils/visualizer.py
+++ b/src/fonduer/utils/visualizer.py
@@ -68,9 +68,7 @@ class Visualizer(object):
         boxes is a list of 5-tuples (page, top, left, bottom, right)
         """
         if not pdf_file:
-            pdf_file = os.path.join(
-                self.pdf_path, candidates[0][0].context.sentence.document.name
-            )
+            pdf_file = os.path.join(self.pdf_path, candidates[0].document.name)
             if os.path.isfile(pdf_file + ".pdf"):
                 pdf_file += ".pdf"
             elif os.path.isfile(pdf_file + ".PDF"):


### PR DESCRIPTION
This PR assumes a mention has attributes like `top`, `left`, `top`, `right`, and `bottom`.
This PR stays as a draft until for example every mention has those attributes.