### PR TITLE
Add Labeler#upsert_keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ Fixed
 ^^^^^
 * `@senwu`_: Fix legacy code bug in ``SymbolTable``.
 
+Added
+^^^^^
+* `@HiromuHota`_: Add Labeler#upsert_keys.
+
 [0.7.0] - 2019-06-12
 --------------------
 

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -351,6 +351,14 @@ def test_e2e(caplog):
     assert L_train[1].shape == (2985, 9)
     assert len(labeler.get_keys()) == 9
 
+    # Test Dropping LabelerKey
+    labeler.drop_keys(["LF_storage_row"])
+    assert len(labeler.get_keys()) == 8
+
+    # Test Upserting LabelerKey
+    labeler.upsert_keys(["LF_storage_row"])
+    assert "LF_storage_row" in [label.name for label in labeler.get_keys()]
+
     L_train_gold = labeler.get_gold_labels(train_cands)
     assert L_train_gold[0].shape == (3493, 1)
 


### PR DESCRIPTION
Like I added `Featurizer#upsert_keys` (#258), I'd like to add `Labeler#upsert_keys`.
The use case is to deploy a generative model (instead of a discriminative model) somewhere different from where you train this generative model.