### PR TITLE
docs: add .mailmap file to clarify git shortlog

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,8 @@
+Johannes Rausch <jrausch@inf.ethz.ch> <38429553+j-rausch@users.noreply.github.com>
+Luke Hsiao <lwhsiao@stanford.edu> <lukehsiao@users.noreply.github.com>
+Payal Bajaj <pabajaj@stanford.edu> 
+Payal Bajaj <pabajaj@stanford.edu> <pabajaj@raiders3.stanford.edu> 
+Prabh <prabhkaran.singh@ust-global.com> PK <prabhkaran.singh@ust-global.com>
+Sen Wu <senwu@cs.stanford.edu>
+Sen Wu <senwu@cs.stanford.edu> <SenWu@users.noreply.github.com>
+Sen Wu <senwu@cs.stanford.edu> <senwu@stanford.edu>


### PR DESCRIPTION
Git supports using a .mailmap file to coalesce commits by the same
person in the shortlog, where their name and/or email address was
spelled differently [1]. This commit adds a .mailmap file for the sake
of having cleaner shortlogs (e.g., not several different entries for the
same person).

This also works for git logs:

```
git config --global log.mailmap true
```

[1] https://git-scm.com/docs/git-shortlog