### PR TITLE
Pluggable visual linker

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,28 @@ Added
 
 * `@HiromuHota`_: Add page argument to get_pdf_dim in case pages have different dimensions.
 * `@HiromuHota`_: Add Labeler#upsert_keys.
+* `@HiromuHota`_: Add `vizlink` as an argument to `Parser` to be able to plug a custom visual linker.
+  Unless otherwise specified, `VisualLinker` will be used by default.
+
+.. note::
+
+    Example usage:
+
+    .. code:: python
+
+        from fonduer.parser.visual_linker import VisualLinker
+        class CustomVisualLinker(VisualLinker):
+            def __init__(self):
+                """Your code"""
+
+            def link(self, document_name: str, sentences: Iterable[Sentence], pdf_path: str) -> Iterable[Sentence]:
+                """Your code"""
+
+            def is_linkable(self, filename: str) -> bool:
+                """Your code"""
+
+        from fonduer.parser import Parser
+        parser = Parser(session, vizlink=CustomVisualLinker())
 
 Fixed
 ^^^^^

--- a/docs/user/parser.rst
+++ b/docs/user/parser.rst
@@ -24,6 +24,11 @@ This is Fonduer_'s core Parser object.
     :inherited-members:
     :show-inheritance:
 
+.. automodule:: fonduer.parser.visual_linker
+    :members:
+    :inherited-members:
+    :show-inheritance:
+
 Preprocessors
 -------------
 

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -229,7 +229,7 @@ class ParserUDF(UDF):
             if self.visual:
                 # Use the provided pdf_path if present
                 self.pdf_path = pdf_path if pdf_path else self.pdf_path
-                if not self.vizlink.valid_pdf(document.name):
+                if not self.vizlink.is_linkable(document.name):
                     warnings.warn(
                         (
                             f"Visual parse failed. "

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -47,7 +47,8 @@ class Parser(UDFRunner):
     :param tabular: Whether to include tabular information in the parse.
     :param visual: Whether to include visual information in the parse.
         Requires PDFs for each input document.
-    :param vizlink: A custom visual linker that inherits :class:`VisualLinker`.
+    :param vizlink: A custom visual linker that inherits
+        :class:`VisualLinker <fonduer.parser.visual_linker.VisualLinker>`.
         Unless otherwise specified, :class:`VisualLinker` will be used. Default None.
     :param pdf_path: The path to the corresponding PDFs use for visual info.
     """

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -47,6 +47,8 @@ class Parser(UDFRunner):
     :param tabular: Whether to include tabular information in the parse.
     :param visual: Whether to include visual information in the parse.
         Requires PDFs for each input document.
+    :param vizlink: A custom visual linker that inherits :class:`VisualLinker`.
+        Unless otherwise specified, :class:`VisualLinker` will be used. Default None.
     :param pdf_path: The path to the corresponding PDFs use for visual info.
     """
 

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -242,7 +242,7 @@ class ParserUDF(UDF):
                     # Add visual attributes
                     return_sentences = [
                         y
-                        for y in self.vizlink.parse_visual(
+                        for y in self.vizlink.link(
                             document.name, document.sentences, self.pdf_path
                         )
                     ]

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -64,6 +64,7 @@ class Parser(UDFRunner):
         replacements=[("[\u2010\u2011\u2012\u2013\u2014\u2212]", "-")],
         tabular=True,  # tabular information
         visual=False,  # visual information
+        vizlink=None,  # visual linker
         pdf_path=None,
     ):
         super(Parser, self).__init__(
@@ -78,6 +79,7 @@ class Parser(UDFRunner):
             replacements=replacements,
             tabular=tabular,
             visual=visual,
+            vizlink=vizlink,
             pdf_path=pdf_path,
             language=language,
         )
@@ -148,6 +150,7 @@ class ParserUDF(UDF):
         replacements,
         tabular,
         visual,
+        vizlink,
         pdf_path,
         language,
         **kwargs,
@@ -202,9 +205,11 @@ class ParserUDF(UDF):
 
         # visual setup
         self.visual = visual
+        self.vizlink = vizlink
         if self.visual:
             self.pdf_path = pdf_path
-            self.vizlink = VisualLinker()
+            if not self.vizlink:
+                self.vizlink = VisualLinker()
 
     def apply(self, document, pdf_path=None, **kwargs):
         # The document is the Document model

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -49,7 +49,7 @@ class Parser(UDFRunner):
         Requires PDFs for each input document.
     :param vizlink: A custom visual linker that inherits
         :class:`VisualLinker <fonduer.parser.visual_linker.VisualLinker>`.
-        Unless otherwise specified, :class:`VisualLinker` will be used. Default None.
+        Unless otherwise specified, :class:`VisualLinker` will be used.
     :param pdf_path: The path to the corresponding PDFs use for visual info.
     """
 

--- a/src/fonduer/parser/visual_linker.py
+++ b/src/fonduer/parser/visual_linker.py
@@ -42,7 +42,7 @@ class VisualLinker(object):
                 f"but should be 0.36.0 or above"
             )
 
-    def parse_visual(self, document_name, sentences, pdf_path):
+    def link(self, document_name, sentences, pdf_path):
         self.sentences = sentences
         self.pdf_file = (
             pdf_path if os.path.isfile(pdf_path) else pdf_path + document_name + ".pdf"

--- a/src/fonduer/parser/visual_linker.py
+++ b/src/fonduer/parser/visual_linker.py
@@ -13,7 +13,8 @@ from editdistance import eval as editdist  # Alternative library: python-levensh
 
 
 class VisualLinker(object):
-    def __init__(self, time=False, verbose=False):
+    def __init__(self, pdf_path, time=False, verbose=False):
+        self.pdf_path = pdf_path
         self.logger = logging.getLogger(__name__)
         self.pdf_file = None
         self.verbose = verbose
@@ -95,6 +96,23 @@ class VisualLinker(object):
         self.pdf_dim = (page_width, page_height)
         if self.verbose:
             self.logger.info(f"Extracted {len(self.pdf_word_list)} pdf words")
+
+    def valid_pdf(self, filename):
+        """Verify that the file exists and has a PDF extension."""
+        path = self.pdf_path
+        # If path is file, but not PDF.
+        if os.path.isfile(path) and path.lower().endswith(".pdf"):
+            return True
+        else:
+            full_path = os.path.join(path, filename)
+            if os.path.isfile(full_path) and full_path.lower().endswith(".pdf"):
+                return True
+            elif os.path.isfile(os.path.join(path, filename + ".pdf")):
+                return True
+            elif os.path.isfile(os.path.join(path, filename + ".PDF")):
+                return True
+
+        return False
 
     def _coordinates_from_HTML(self, page, page_num):
         pdf_word_list = []

--- a/src/fonduer/parser/visual_linker.py
+++ b/src/fonduer/parser/visual_linker.py
@@ -13,6 +13,8 @@ from editdistance import eval as editdist  # Alternative library: python-levensh
 
 
 class VisualLinker(object):
+    """Link visual information with sentences."""
+
     def __init__(self, pdf_path, time=False, verbose=False):
         self.pdf_path = pdf_path
         self.logger = logging.getLogger(__name__)
@@ -43,6 +45,17 @@ class VisualLinker(object):
             )
 
     def link(self, document_name, sentences, pdf_path):
+        """Link visual information with sentences.
+
+        :param document_name: the document name.
+        :type document_name: str
+        :param sentences: sentences to be linked with visual information.
+        :type sentences: Iterable[Sentence]
+        :param pdf_path: The path to the PDF documents, if any. This path will
+            override the one used in initialization, if provided.
+        :type pdf_path: str
+        :rtype: A generator of ``Sentence``.
+        """
         self.sentences = sentences
         self.pdf_file = (
             pdf_path if os.path.isfile(pdf_path) else pdf_path + document_name + ".pdf"
@@ -98,7 +111,12 @@ class VisualLinker(object):
             self.logger.info(f"Extracted {len(self.pdf_word_list)} pdf words")
 
     def is_linkable(self, filename):
-        """Verify that the file exists and has a PDF extension."""
+        """Verify that the file exists and has a PDF extension.
+
+        :param filename: The path to the PDF document.
+        :type filename: str
+        :rtype: boolean
+        """
         path = self.pdf_path
         # If path is file, but not PDF.
         if os.path.isfile(path) and path.lower().endswith(".pdf"):

--- a/src/fonduer/parser/visual_linker.py
+++ b/src/fonduer/parser/visual_linker.py
@@ -97,7 +97,7 @@ class VisualLinker(object):
         if self.verbose:
             self.logger.info(f"Extracted {len(self.pdf_word_list)} pdf words")
 
-    def valid_pdf(self, filename):
+    def is_linkable(self, filename):
         """Verify that the file exists and has a PDF extension."""
         path = self.pdf_path
         # If path is file, but not PDF.

--- a/src/fonduer/parser/visual_linker.py
+++ b/src/fonduer/parser/visual_linker.py
@@ -50,16 +50,16 @@ class VisualLinker(object):
         if not os.path.isfile(self.pdf_file):
             self.pdf_file = self.pdf_file[:-3] + "PDF"
         try:
-            self.extract_pdf_words()
+            self._extract_pdf_words()
         except RuntimeError as e:
             self.logger.exception(e)
             return
-        self.extract_html_words()
-        self.link_lists(search_max=200)
-        for sentence in self.update_coordinates():
+        self._extract_html_words()
+        self._link_lists(search_max=200)
+        for sentence in self._update_coordinates():
             yield sentence
 
-    def extract_pdf_words(self):
+    def _extract_pdf_words(self):
         self.logger.debug(
             f"pdfinfo '{self.pdf_file}' | grep -a ^Pages: | sed 's/[^0-9]*//'"
         )
@@ -152,7 +152,7 @@ class VisualLinker(object):
         )
         return pdf_word_list, coordinate_map
 
-    def extract_html_words(self):
+    def _extract_html_words(self):
         html_word_list = []
         for sentence in self.sentences:
             for i, word in enumerate(sentence.words):
@@ -161,7 +161,7 @@ class VisualLinker(object):
         if self.verbose:
             self.logger.info(f"Extracted {len(self.html_word_list)} html words")
 
-    def link_lists(self, search_max=100, edit_cost=20, offset_cost=1):
+    def _link_lists(self, search_max=100, edit_cost=20, offset_cost=1):
         # NOTE: there are probably some inefficiencies here from rehashing words
         # multiple times, but we're not going to worry about that for now
 
@@ -302,7 +302,7 @@ class VisualLinker(object):
                 pass
         return int(np.median(offsets))
 
-    def display_links(self, max_rows=100):
+    def _display_links(self, max_rows=100):
         html = []
         pdf = []
         j = []
@@ -336,7 +336,7 @@ class VisualLinker(object):
         self.logger.info(pd.DataFrame(data, columns=["html", "pdf", "j"]))
         pd.reset_option("display.max_rows")
 
-    def update_coordinates(self):
+    def _update_coordinates(self):
         for sentence in self.sentences:
             (page, top, left, bottom, right) = list(
                 zip(

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -24,6 +24,7 @@ def get_parser_udf(
     replacements=[("[\u2010\u2011\u2012\u2013\u2014\u2212]", "-")],
     tabular=True,  # tabular information
     visual=False,  # visual information
+    vizlink=None,
     pdf_path=None,
 ):
     """Return an instance of ParserUDF."""
@@ -41,6 +42,7 @@ def get_parser_udf(
             replacements=replacements,
             tabular=tabular,
             visual=visual,
+            vizlink=vizlink,
             pdf_path=pdf_path,
             language=language,
         )


### PR DESCRIPTION
This patch addresses #260 by adding `vizlink` as an argument to `Parser` to be able to plug a custom visual linker.
Unless otherwise specified, `VisualLinker` will be used by default for backward-compatibility.