### PR TITLE
Dockerfile for Fonduer Runtime Environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,11 @@ ENV VIRTUAL_ENV=/home/user/.venv
 RUN python -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+
+ARG FONDUER_VERSION=
 # Install python packages
+# Set --build-arg FONDUER_VERSION=0.7.0 to install a specific version of Fonduer,
+# otherwise the lastest version is installed.
 RUN pip install \
     https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-linux_x86_64.whl \
-    fonduer==0.7.0
+    fonduer${FONDUER_VERSION:+==${FONDUER_VERSION}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.7-slim
+LABEL maintainer="Hiromu Hota <hiromu.hota@hal.hitachi.com>"
+
+# https://github.com/debuerreotype/debuerreotype/issues/10
+RUN seq 1 8 | xargs -I{} mkdir -p /usr/share/man/man{}
+
+# Install deb packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    poppler-utils \
+    postgresql-client \
+    libmagickwand-dev \
+ && rm /etc/ImageMagick-6/policy.xml \
+ && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+# Create a user and its virtual environment
+RUN groupadd user && useradd -r -m -g user user
+USER user
+WORKDIR /home/user
+ENV VIRTUAL_ENV=/home/user/.venv
+RUN python -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Install python packages
+RUN pip install \
+    https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-linux_x86_64.whl \
+    fonduer==0.7.0


### PR DESCRIPTION
Suppose _hiromuhota/fonduer_ is the Docker image for fonduer, and _hiromuhota/fonduer-tutorials_ is for fonduer-tutorials.
I'll submit another PR for fonduer-tutorials, where Dockerfile builds from _hiromuhota/fonduer_.

Both of the two images (fonduer and fonduer-tutorials) will migrate from [hiromuhota](https://hub.docker.com/u/hiromuhota) to [hazyresearch](https://hub.docker.com/u/hazyresearch) at Docker Hub.