### PR TITLE
Fix the type of max_docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,6 +71,7 @@ Changed
 Fixed
 ^^^^^
 * `@senwu`_: Fix legacy code bug in ``SymbolTable``.
+* `@HiromuHota`_: Fix the type of max_docs.
 
 [0.7.0] - 2019-06-12
 --------------------

--- a/src/fonduer/parser/preprocessors/doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/doc_preprocessor.py
@@ -16,7 +16,7 @@ class DocPreprocessor(object):
     :rtype: A generator of ``Documents``.
     """
 
-    def __init__(self, path, encoding="utf-8", max_docs=float("inf")):
+    def __init__(self, path, encoding="utf-8", max_docs=None):
         self.path = path
         self.encoding = encoding
         self.max_docs = max_docs
@@ -29,7 +29,7 @@ class DocPreprocessor(object):
             for doc in self._get_docs_for_path(fp):
                 yield doc
                 doc_count += 1
-                if doc_count >= self.max_docs:
+                if self.max_docs and doc_count >= self.max_docs:
                     return
 
     def __len__(self):


### PR DESCRIPTION
While max_docs is meant to be int, float("inf") is a float.
In Python 3, there is no "inf" for int.
Make the default value of max_docs None as a workaround.