### PR TITLE
Type annotations-1 (related to #290)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -59,6 +59,7 @@ Added
 
 * `@HiromuHota`_: Add `LingualParser`, which any lingual parser like `Spacy` should inherit from,
   and add `lingual_parser` as an argument to `Parser` to be able to plug a custom lingual parser.
+* `@HiromuHota`_: Annotate types to some of the classes incl. preprocesssors and parser/models.
 
 Changed
 ^^^^^^^
@@ -67,6 +68,11 @@ Changed
 * `@HiromuHota`_: Rename SimpleTokenizer into SimpleParser and let it inherit LingualParser.
 * `@HiromuHota`_: Move all ligual parsers into lingual_parser folder.
 * `@HiromuHota`_: Make load_lang_model private as a model is internally loaded during init.
+
+Removed
+^^^^^^^
+
+* `@HiromuHota`_: Remove __repr__ from each mixin class as the referenced attributes are not available.
 
 Fixed
 ^^^^^

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,6 @@ check:
 	black tests/ --check
 	flake8 src/
 	flake8 tests/
-	mypy src/
-	mypy tests/
-
 
 docs:
 	sphinx-build -W -b html docs/ _build/html

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ check:
 	black tests/ --check
 	flake8 src/
 	flake8 tests/
-	mypy --ignore-missing-imports src/
-	mypy --ignore-missing-imports tests/
+	mypy src/
+	mypy tests/
 
 
 docs:

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ check:
 	black tests/ --check
 	flake8 src/
 	flake8 tests/
+	mypy --ignore-missing-imports src/
+	mypy --ignore-missing-imports tests/
+
 
 docs:
 	sphinx-build -W -b html docs/ _build/html

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,48 @@
+[mypy]
+disallow_untyped_defs = True
+
+[mypy-sqlalchemy.*]
+ignore_missing_imports = True
+
+[mypy-numpy.*]
+ignore_missing_imports = True
+
+[mypy-spacy.*]
+ignore_missing_imports = True
+
+[mypy-tensorboardX.*]
+ignore_missing_imports = True
+
+[mypy-treedlib.*]
+ignore_missing_imports = True
+
+[mypy-lxml.*]
+ignore_missing_imports = True
+
+[mypy-bs4.*]
+ignore_missing_imports = True
+
+[mypy-wand.*]
+ignore_missing_imports = True
+
+[mypy-pandas.*]
+ignore_missing_imports = True
+
+[mypy-IPython.*]
+ignore_missing_imports = True
+
+[mypy-sklearn.*]
+ignore_missing_imports = True
+
+[mypy-scipy.*]
+ignore_missing_imports = True
+
+[mypy-tqdm.*]
+ignore_missing_imports = True
+
+[mypy-editdistance.*]
+ignore_missing_imports = True
+
+[mypy-nltk.*]
+ignore_missing_imports = True
+

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 disallow_untyped_defs = True
+strict_optional = False
 
 [mypy-sqlalchemy.*]
 ignore_missing_imports = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 black>=18.9b0
 flake8
+mypy
 isort
 pre-commit
 pytest

--- a/src/fonduer/candidates/models/candidate.py
+++ b/src/fonduer/candidates/models/candidate.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 candidate_subclasses = {}
 
 
-class Candidate(Meta.Base):
+class Candidate(Meta.Base):  # type: ignore
     """
     An abstract candidate relation.
 

--- a/src/fonduer/candidates/models/candidate.py
+++ b/src/fonduer/candidates/models/candidate.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Dict, Tuple
 
 from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import backref, relationship
@@ -11,7 +12,7 @@ logger = logging.getLogger(__name__)
 # This global dictionary contains all classes that have been declared in this
 # Python environment, so that candidate_subclass() can return a class if it
 # already exists and is identical in specification to the requested class
-candidate_subclasses = {}
+candidate_subclasses: Dict[str, Tuple] = {}
 
 
 class Candidate(Meta.Base):  # type: ignore

--- a/src/fonduer/candidates/models/mention.py
+++ b/src/fonduer/candidates/models/mention.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Dict, Tuple
 
 from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import backref, relationship
@@ -11,7 +12,7 @@ logger = logging.getLogger(__name__)
 # This global dictionary contains all classes that have been declared in this
 # Python environment, so that mention_subclass() can return a class if it
 # already exists and is identical in specification to the requested class.
-mention_subclasses = {}
+mention_subclasses: Dict[str, Tuple] = {}
 
 
 class Mention(Meta.Base):  # type: ignore

--- a/src/fonduer/candidates/models/mention.py
+++ b/src/fonduer/candidates/models/mention.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 mention_subclasses = {}
 
 
-class Mention(Meta.Base):
+class Mention(Meta.Base):  # type: ignore
     """
     An abstract Mention.
 

--- a/src/fonduer/features/feature_libs/structural_features.py
+++ b/src/fonduer/features/feature_libs/structural_features.py
@@ -1,3 +1,5 @@
+from typing import Dict, Set
+
 from fonduer.candidates.models.span_mention import TemporarySpanMention
 from fonduer.utils.data_model_utils import (
     common_ancestor,
@@ -15,8 +17,8 @@ from fonduer.utils.data_model_utils import (
 FEATURE_PREFIX = "STR_"
 DEF_VALUE = 1
 
-unary_strlib_feats = {}
-binary_strlib_feats = {}
+unary_strlib_feats: Dict[str, Set] = {}
+binary_strlib_feats: Dict[str, Set] = {}
 
 
 def extract_structural_features(candidates):

--- a/src/fonduer/features/feature_libs/tabular_features.py
+++ b/src/fonduer/features/feature_libs/tabular_features.py
@@ -1,3 +1,5 @@
+from typing import Dict, Set
+
 from fonduer.candidates.models.span_mention import TemporarySpanMention
 from fonduer.utils.config import get_config
 from fonduer.utils.data_model_utils import (
@@ -11,8 +13,8 @@ from fonduer.utils.utils_table import min_col_diff, min_row_diff, num_cols, num_
 FEAT_PRE = "TAB_"
 DEF_VALUE = 1
 
-unary_tablelib_feats = {}
-binary_tablelib_feats = {}
+unary_tablelib_feats: Dict[str, Set] = {}
+binary_tablelib_feats: Dict[str, Set] = {}
 
 settings = get_config()
 

--- a/src/fonduer/features/feature_libs/textual_features.py
+++ b/src/fonduer/features/feature_libs/textual_features.py
@@ -1,4 +1,5 @@
 from builtins import range
+from typing import Dict, Set
 
 from treedlib import (
     Children,
@@ -23,10 +24,10 @@ from fonduer.utils.utils import get_as_dict, tokens_to_ngrams
 
 DEF_VALUE = 1
 
-unary_ddlib_feats = {}
-unary_word_feats = {}
-unary_tdl_feats = {}
-binary_tdl_feats = {}
+unary_ddlib_feats: Dict[str, Set] = {}
+unary_word_feats: Dict[str, Set] = {}
+unary_tdl_feats: Dict[str, Set] = {}
+binary_tdl_feats: Dict[str, Set] = {}
 settings = get_config()
 
 

--- a/src/fonduer/features/feature_libs/visual_features.py
+++ b/src/fonduer/features/feature_libs/visual_features.py
@@ -1,3 +1,5 @@
+from typing import Dict, Set
+
 from fonduer.candidates.models.span_mention import TemporarySpanMention
 from fonduer.utils.data_model_utils import (
     get_visual_aligned_lemmas,
@@ -12,8 +14,8 @@ from fonduer.utils.data_model_utils import (
 FEAT_PRE = "VIZ_"
 DEF_VALUE = 1
 
-unary_vizlib_feats = {}
-binary_vizlib_feats = {}
+unary_vizlib_feats: Dict[str, Set] = {}
+binary_vizlib_feats: Dict[str, Set] = {}
 
 
 def extract_visual_features(candidates):

--- a/src/fonduer/features/models/feature.py
+++ b/src/fonduer/features/models/feature.py
@@ -5,13 +5,13 @@ from fonduer.meta import Meta
 from fonduer.utils.models.annotation import AnnotationKeyMixin, AnnotationMixin
 
 
-class FeatureKey(AnnotationKeyMixin, Meta.Base):
+class FeatureKey(AnnotationKeyMixin, Meta.Base):  # type: ignore
     """A feature's key that identifies the definition of the Feature."""
 
     pass
 
 
-class Feature(AnnotationMixin, Meta.Base):
+class Feature(AnnotationMixin, Meta.Base):  # type: ignore
     """An element of a representation of a Candidate in a feature space.
 
     A Feature's annotation key identifies the definition of the Feature, e.g.,

--- a/src/fonduer/learning/classifier.py
+++ b/src/fonduer/learning/classifier.py
@@ -11,7 +11,7 @@ import torch.nn.functional as F
 import torch.optim as optim
 from sklearn.metrics import roc_auc_score
 from torch.utils.data import DataLoader
-from torch.utils.data.dataloader import default_collate
+from torch.utils.data.dataloader import default_collate  # type: ignore
 
 from fonduer import Meta
 from fonduer.learning.disc_models.modules.loss import SoftCrossEntropyLoss

--- a/src/fonduer/learning/models/marginal.py
+++ b/src/fonduer/learning/models/marginal.py
@@ -3,7 +3,7 @@ from sqlalchemy import Boolean, Column, Float, ForeignKey, Integer, UniqueConstr
 from fonduer.meta import Meta
 
 
-class Marginal(Meta.Base):
+class Marginal(Meta.Base):  # type: ignore
     """
     A marginal probability corresponding to a (Candidate, value) pair.
 

--- a/src/fonduer/learning/models/prediction.py
+++ b/src/fonduer/learning/models/prediction.py
@@ -4,11 +4,11 @@ from fonduer.meta import Meta
 from fonduer.utils.models.annotation import AnnotationKeyMixin, AnnotationMixin
 
 
-class PredictionKey(AnnotationKeyMixin, Meta.Base):
+class PredictionKey(AnnotationKeyMixin, Meta.Base):  # type: ignore
     pass
 
 
-class Prediction(AnnotationMixin, Meta.Base):
+class Prediction(AnnotationMixin, Meta.Base):  # type: ignore
     """
     A probability associated with a Candidate, indicating the degree of belief
     that the Candidate is true.

--- a/src/fonduer/meta.py
+++ b/src/fonduer/meta.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import logging
 import os
 import tempfile
 from builtins import object
 from datetime import datetime
+from typing import Optional, Type
 from urllib.parse import urlparse
 
 import sqlalchemy
@@ -14,10 +17,10 @@ logger = logging.getLogger(__name__)
 
 
 def init_logging(
-    log_dir=tempfile.gettempdir(),
-    format="[%(asctime)s][%(levelname)s] %(name)s:%(lineno)s - %(message)s",
-    level=logging.INFO,
-):
+    log_dir: str = tempfile.gettempdir(),
+    format: str = "[%(asctime)s][%(levelname)s] %(name)s:%(lineno)s - %(message)s",
+    level: int = logging.INFO,
+) -> None:
     """Configures logging to output to the provided log_dir.
 
     Will use a nested directory whose name is the current timestamp.
@@ -58,7 +61,7 @@ def init_logging(
 
 
 # Defines procedure for setting up a sessionmaker
-def new_sessionmaker():
+def new_sessionmaker() -> sessionmaker:
     # Turning on autocommit for Postgres, see
     # http://oddbird.net/2014/06/14/sqlalchemy-postgres-autocommit/
     # Otherwise any e.g. query starts a transaction, locking tables... very
@@ -89,7 +92,7 @@ def new_sessionmaker():
     return sessionmaker(bind=engine)
 
 
-def _update_meta(conn_string):
+def _update_meta(conn_string: str) -> None:
     """Update Meta class."""
     url = urlparse(conn_string)
     Meta.conn_string = conn_string
@@ -109,20 +112,20 @@ class Meta(object):
     """
 
     # Static class variables
-    conn_string = None
-    DBNAME = None
-    DBUSER = None
-    DBHOST = None
-    DBPORT = None
-    DBPWD = None
+    conn_string: Optional[str] = None
+    DBNAME: Optional[str] = None
+    DBUSER: Optional[str] = None
+    DBHOST: Optional[str] = None
+    DBPORT: Optional[int] = None
+    DBPWD: Optional[str] = None
     Session = None
     engine = None
     Base = declarative_base(name="Base", cls=object)
     postgres = False
-    log_path = None
+    log_path: Optional[str] = None
 
     @classmethod
-    def init(cls, conn_string=None):
+    def init(cls, conn_string: Optional[str] = None) -> Type[Meta]:
         """Return the unique Meta class."""
         if conn_string:
             _update_meta(conn_string)
@@ -142,7 +145,7 @@ class Meta(object):
         return cls
 
     @classmethod
-    def _init_db(cls):
+    def _init_db(cls) -> None:
         """ Initialize the storage schema.
 
         This call must be performed after all classes that extend

--- a/src/fonduer/meta.py
+++ b/src/fonduer/meta.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import os
 import tempfile
@@ -125,7 +123,7 @@ class Meta(object):
     log_path: Optional[str] = None
 
     @classmethod
-    def init(cls, conn_string: Optional[str] = None) -> Type[Meta]:
+    def init(cls, conn_string: Optional[str] = None) -> Type["Meta"]:
         """Return the unique Meta class."""
         if conn_string:
             _update_meta(conn_string)

--- a/src/fonduer/parser/models/caption.py
+++ b/src/fonduer/parser/models/caption.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import backref, relationship
 
@@ -55,7 +57,7 @@ class Caption(Context):
 
     __table_args__ = (UniqueConstraint(document_id, table_id, figure_id, position),)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.figure:
             return (
                 f"Caption("
@@ -77,6 +79,6 @@ class Caption(Context):
                 "Caption must be associated with Figure or Table."
             )
 
-    def __gt__(self, other):
+    def __gt__(self, other: Caption) -> bool:
         # Allow sorting by comparing the string representations of each
         return self.__repr__() > other.__repr__()

--- a/src/fonduer/parser/models/caption.py
+++ b/src/fonduer/parser/models/caption.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import backref, relationship
 
@@ -79,6 +77,6 @@ class Caption(Context):
                 "Caption must be associated with Figure or Table."
             )
 
-    def __gt__(self, other: Caption) -> bool:
+    def __gt__(self, other: "Caption") -> bool:
         # Allow sorting by comparing the string representations of each
         return self.__repr__() > other.__repr__()

--- a/src/fonduer/parser/models/context.py
+++ b/src/fonduer/parser/models/context.py
@@ -3,7 +3,7 @@ from sqlalchemy import Column, Integer, String
 from fonduer.meta import Meta
 
 
-class Context(Meta.Base):
+class Context(Meta.Base):  # type: ignore
     """A piece of content from which Candidates are composed.
 
     This serves as the base class of the Fonduer document model.

--- a/src/fonduer/parser/models/document.py
+++ b/src/fonduer/parser/models/document.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sqlalchemy import Column, ForeignKey, Integer, String
 from sqlalchemy.types import PickleType
 
@@ -31,9 +33,9 @@ class Document(Context):
 
     __mapper_args__ = {"polymorphic_identity": "document"}
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Document {self.name}"
 
-    def __gt__(self, other):
+    def __gt__(self, other: Document) -> bool:
         # Allow sorting by comparing the string representations of each
         return self.__repr__() > other.__repr__()

--- a/src/fonduer/parser/models/document.py
+++ b/src/fonduer/parser/models/document.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from sqlalchemy import Column, ForeignKey, Integer, String
 from sqlalchemy.types import PickleType
 
@@ -36,6 +34,6 @@ class Document(Context):
     def __repr__(self) -> str:
         return f"Document {self.name}"
 
-    def __gt__(self, other: Document) -> bool:
+    def __gt__(self, other: "Document") -> bool:
         # Allow sorting by comparing the string representations of each
         return self.__repr__() > other.__repr__()

--- a/src/fonduer/parser/models/figure.py
+++ b/src/fonduer/parser/models/figure.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import backref, relationship
 
@@ -80,6 +78,6 @@ class Figure(Context):
                 f")"
             )
 
-    def __gt__(self, other: Figure) -> bool:
+    def __gt__(self, other: "Figure") -> bool:
         # Allow sorting by comparing the string representations of each
         return self.__repr__() > other.__repr__()

--- a/src/fonduer/parser/models/figure.py
+++ b/src/fonduer/parser/models/figure.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import backref, relationship
 
@@ -57,7 +59,7 @@ class Figure(Context):
 
     __table_args__ = (UniqueConstraint(document_id, position),)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.cell:
             return (
                 f"Figure("
@@ -78,6 +80,6 @@ class Figure(Context):
                 f")"
             )
 
-    def __gt__(self, other):
+    def __gt__(self, other: Figure) -> bool:
         # Allow sorting by comparing the string representations of each
         return self.__repr__() > other.__repr__()

--- a/src/fonduer/parser/models/paragraph.py
+++ b/src/fonduer/parser/models/paragraph.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import backref, relationship
 
@@ -96,6 +94,6 @@ class Paragraph(Context):
                 f")"
             )
 
-    def __gt__(self, other: Paragraph) -> bool:
+    def __gt__(self, other: "Paragraph") -> bool:
         # Allow sorting by comparing the string representations of each
         return self.__repr__() > other.__repr__()

--- a/src/fonduer/parser/models/paragraph.py
+++ b/src/fonduer/parser/models/paragraph.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import backref, relationship
 
@@ -66,7 +68,7 @@ class Paragraph(Context):
 
     __table_args__ = (UniqueConstraint(document_id, position),)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.cell:
             return (
                 f"Paragraph("
@@ -94,6 +96,6 @@ class Paragraph(Context):
                 f")"
             )
 
-    def __gt__(self, other):
+    def __gt__(self, other: Paragraph) -> bool:
         # Allow sorting by comparing the string representations of each
         return self.__repr__() > other.__repr__()

--- a/src/fonduer/parser/models/section.py
+++ b/src/fonduer/parser/models/section.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import backref, relationship
 
@@ -37,9 +39,9 @@ class Section(Context):
 
     __table_args__ = (UniqueConstraint(document_id, position),)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Section(Doc: {self.document.name}, Pos: {self.position})"
 
-    def __gt__(self, other):
+    def __gt__(self, other: Section) -> bool:
         # Allow sorting by comparing the string representations of each
         return self.__repr__() > other.__repr__()

--- a/src/fonduer/parser/models/section.py
+++ b/src/fonduer/parser/models/section.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import backref, relationship
 
@@ -42,6 +40,6 @@ class Section(Context):
     def __repr__(self) -> str:
         return f"Section(Doc: {self.document.name}, Pos: {self.position})"
 
-    def __gt__(self, other: Section) -> bool:
+    def __gt__(self, other: "Section") -> bool:
         # Allow sorting by comparing the string representations of each
         return self.__repr__() > other.__repr__()

--- a/src/fonduer/parser/models/sentence.py
+++ b/src/fonduer/parser/models/sentence.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from builtins import object
+from typing import Any, Dict
 
 from sqlalchemy import Column, ForeignKey, Integer, String, Text, UniqueConstraint
 from sqlalchemy.dialects import postgresql
@@ -14,83 +17,65 @@ STR_ARRAY_TYPE = postgresql.ARRAY(String)
 class SentenceMixin(object):
     """A sentence Context in a Document."""
 
-    def is_lingual(self):
+    def is_lingual(self) -> bool:
         return False
 
-    def is_visual(self):
+    def is_visual(self) -> bool:
         return False
 
-    def is_tabular(self):
+    def is_tabular(self) -> bool:
         return False
 
-    def is_structural(self):
+    def is_structural(self) -> bool:
         return False
-
-    def __repr__(self):
-        return (
-            f"Sentence ("
-            f"Doc: {self.document.name}, "
-            f"Index: {self.sentence_idx}, "
-            f"Text: {self.text}"
-            f")"
-        )
 
 
 class LingualMixin(object):
     """A collection of lingual attributes."""
 
     @declared_attr
-    def lemmas(cls):
+    def lemmas(cls) -> Column:
         """A list of the lemmas for each word in a ``Sentence``."""
         return Column(STR_ARRAY_TYPE)
 
     @declared_attr
-    def pos_tags(cls):
+    def pos_tags(cls) -> Column:
         """A list of POS tags for each word in a ``Sentence``."""
         return Column(STR_ARRAY_TYPE)
 
     @declared_attr
-    def ner_tags(cls):
+    def ner_tags(cls) -> Column:
         """A list of NER tags for each word in a ``Sentence``."""
         return Column(STR_ARRAY_TYPE)
 
     @declared_attr
-    def dep_parents(cls):
+    def dep_parents(cls) -> Column:
         """A list of the dependency parents for each word in a ``Sentence``."""
         return Column(INT_ARRAY_TYPE)
 
     @declared_attr
-    def dep_labels(cls):
+    def dep_labels(cls) -> Column:
         """A list of dependency labels for each word in a ``Sentence``."""
         return Column(STR_ARRAY_TYPE)
 
-    def is_lingual(self):
+    def is_lingual(self) -> bool:
         """Whether or not the ``Sentence`` contains NLP information.
 
         :rtype: bool
         """
         return self.lemmas is not None
 
-    def __repr__(self):
-        return (
-            f"LingualSentence ("
-            f"Doc: {self.document.name}, "
-            f"Index: {self.sentence_idx}, "
-            f"Text: {self.text}"
-            f")"
-        )
-
 
 class TabularMixin(object):
     """A collection of tabular attributes."""
 
     @declared_attr
-    def table_id(cls):
+    def table_id(cls) -> Column:
         """The id of the parent ``Table``, if any."""
         return Column("table_id", ForeignKey("table.id"))
 
     @declared_attr
-    def table(cls):
+    def table(cls) -> relationship:
         """The parent ``Table``, if any."""
         return relationship(
             "Table",
@@ -99,12 +84,12 @@ class TabularMixin(object):
         )
 
     @declared_attr
-    def cell_id(cls):
+    def cell_id(cls) -> Column:
         """The id of the parent ``Cell``, if any."""
         return Column("cell_id", ForeignKey("cell.id"))
 
     @declared_attr
-    def cell(cls):
+    def cell(cls) -> relationship:
         """The parent ``Cell``, if any."""
         return relationship(
             "Cell",
@@ -113,66 +98,45 @@ class TabularMixin(object):
         )
 
     @declared_attr
-    def row_start(cls):
+    def row_start(cls) -> Column:
         """The ``row_start`` of the parent ``Cell``, if any."""
         return Column(Integer)
 
     @declared_attr
-    def row_end(cls):
+    def row_end(cls) -> Column:
         """The ``row_end`` of the parent ``Cell``, if any."""
         return Column(Integer)
 
     @declared_attr
-    def col_start(cls):
+    def col_start(cls) -> Column:
         """The ``col_start`` of the parent ``Cell``, if any."""
         return Column(Integer)
 
     @declared_attr
-    def col_end(cls):
+    def col_end(cls) -> Column:
         """The ``col_end`` of the parent ``Cell``, if any."""
         return Column(Integer)
 
-    def is_tabular(self):
+    def is_tabular(self) -> bool:
         """Whether or not the ``Sentence`` contains tabular information.
 
         :rtype: bool
         """
         return self.table is not None
 
-    def is_cellular(self):
+    def is_cellular(self) -> bool:
         """Whether or not the ``Sentence`` contains information about its table cell.
 
         :rtype: bool
         """
         return self.cell is not None
 
-    def __repr__(self):
-        rows = (
-            tuple([self.row_start, self.row_end])
-            if self.row_start != self.row_end
-            else self.row_start
-        )
-        cols = (
-            tuple([self.col_start, self.col_end])
-            if self.col_start != self.col_end
-            else self.col_start
-        )
-        return (
-            f"TabularSentence (Doc: {self.document.name}, "
-            f"Table: {(lambda: self.table).position}, "
-            f"Row: {rows}, "
-            f"Col: {cols}, "
-            f"Index: {self.sentence_idx}, "
-            f"Text: {self.text}"
-            f")"
-        )
-
 
 class VisualMixin(object):
     """A collection of visual attributes."""
 
     @declared_attr
-    def page(cls):
+    def page(cls) -> Column:
         """A list of the page index of each word in the ``Sentence``.
 
         Page indexes start at 0.
@@ -180,77 +144,58 @@ class VisualMixin(object):
         return Column(INT_ARRAY_TYPE)
 
     @declared_attr
-    def top(cls):
+    def top(cls) -> Column:
         """A list of each word's TOP bounding box coordinate in the ``Sentence``."""
         return Column(INT_ARRAY_TYPE)
 
     @declared_attr
-    def left(cls):
+    def left(cls) -> Column:
         """A list of each word's LEFT bounding box coordinate in the ``Sentence``."""
         return Column(INT_ARRAY_TYPE)
 
     @declared_attr
-    def bottom(cls):
+    def bottom(cls) -> Column:
         """A list of each word's BOTTOM bounding box coordinate in the ``Sentence``."""
         return Column(INT_ARRAY_TYPE)
 
     @declared_attr
-    def right(cls):
+    def right(cls) -> Column:
         """A list of each word's RIGHT bounding box coordinate in the ``Sentence``."""
         return Column(INT_ARRAY_TYPE)
 
-    def is_visual(self):
+    def is_visual(self) -> bool:
         """Whether or not the ``Sentence`` contains visual information.
 
         :rtype: bool
         """
         return self.page is not None and self.page[0] is not None
 
-    def __repr__(self):
-        return (
-            f"VisualSentence ("
-            f"Doc: {self.document.name}, "
-            f"Page: {self.page}, "
-            f"(T,B,L,R): ({self.top},{self.bottom},{self.left},{self.right}), "
-            f"Text: {self.text}"
-            f")"
-        )
-
 
 class StructuralMixin(object):
     """A collection of structural attributes."""
 
     @declared_attr
-    def xpath(cls):
+    def xpath(cls) -> Column:
         """The HTML XPATH to the ``Sentence``."""
         return Column(String)
 
     @declared_attr
-    def html_tag(cls):
+    def html_tag(cls) -> Column:
         """The HTML tag of the element containing the ``Sentence``."""
         return Column(String)
 
     #: The HTML attributes of the element the ``Sentence`` is found in.
     @declared_attr
-    def html_attrs(cls):
+    def html_attrs(cls) -> Column:
         """A list of the html attributes of the element containing the ``Sentence``."""
         return Column(STR_ARRAY_TYPE)
 
-    def is_structural(self):
+    def is_structural(self) -> bool:
         """Whether or not the ``Sentence`` contains structural information.
 
         :rtype: bool
         """
         return self.html_tag is not None
-
-    def __repr__(self):
-        return (
-            f"StructuralSentence ("
-            f"Doc: {self.document.name}, "
-            f"Tag: {self.html_tag}, "
-            f"Text: {self.text}"
-            f")"
-        )
 
 
 # SentenceMixin must come last in arguments to not ovewrite is_* methods
@@ -322,7 +267,7 @@ class Sentence(
 
     __table_args__ = (UniqueConstraint(document_id, position),)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.is_tabular():
             rows = (
                 tuple([self.row_start, self.row_end])
@@ -356,7 +301,7 @@ class Sentence(
                 f")"
             )
 
-    def _asdict(self):
+    def _asdict(self) -> Dict[str, Any]:
         return {
             # base
             "id": self.id,
@@ -386,6 +331,6 @@ class Sentence(
             "right": self.right,
         }
 
-    def __gt__(self, other):
+    def __gt__(self, other: Sentence) -> bool:
         # Allow sorting by comparing the string representations of each
         return self.__repr__() > other.__repr__()

--- a/src/fonduer/parser/models/sentence.py
+++ b/src/fonduer/parser/models/sentence.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from builtins import object
 from typing import Any, Dict
 
@@ -331,6 +329,6 @@ class Sentence(
             "right": self.right,
         }
 
-    def __gt__(self, other: Sentence) -> bool:
+    def __gt__(self, other: "Sentence") -> bool:
         # Allow sorting by comparing the string representations of each
         return self.__repr__() > other.__repr__()

--- a/src/fonduer/parser/models/table.py
+++ b/src/fonduer/parser/models/table.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import backref, relationship
 
@@ -56,7 +54,7 @@ class Table(Context):
             f")"
         )
 
-    def __gt__(self, other: Table) -> bool:
+    def __gt__(self, other: "Table") -> bool:
         # Allow sorting by comparing the string representations of each
         return self.__repr__() > other.__repr__()
 
@@ -122,6 +120,6 @@ class Cell(Context):
             f"Pos: {self.position})"
         )
 
-    def __gt__(self, other: Cell) -> bool:
+    def __gt__(self, other: "Cell") -> bool:
         # Allow sorting by comparing the string representations of each
         return self.__repr__() > other.__repr__()

--- a/src/fonduer/parser/models/table.py
+++ b/src/fonduer/parser/models/table.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import backref, relationship
 
@@ -45,7 +47,7 @@ class Table(Context):
 
     __table_args__ = (UniqueConstraint(document_id, position),)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"Table("
             f"Doc: {self.document.name}, "
@@ -54,7 +56,7 @@ class Table(Context):
             f")"
         )
 
-    def __gt__(self, other):
+    def __gt__(self, other: Table) -> bool:
         # Allow sorting by comparing the string representations of each
         return self.__repr__() > other.__repr__()
 
@@ -111,7 +113,7 @@ class Cell(Context):
 
     __table_args__ = (UniqueConstraint(document_id, table_id, position),)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"Cell(Doc: {self.document.name}, "
             f"Table: {self.table.position}, "
@@ -120,6 +122,6 @@ class Cell(Context):
             f"Pos: {self.position})"
         )
 
-    def __gt__(self, other):
+    def __gt__(self, other: Cell) -> bool:
         # Allow sorting by comparing the string representations of each
         return self.__repr__() > other.__repr__()

--- a/src/fonduer/parser/models/utils.py
+++ b/src/fonduer/parser/models/utils.py
@@ -1,12 +1,16 @@
+from typing import Tuple
+
+from fonduer.parser.models import Context
+
 """Utilities for constructing and splitting stable ids."""
 
 
 def construct_stable_id(
-    parent_context,
-    polymorphic_type,
-    relative_char_offset_start,
-    relative_char_offset_end,
-):
+    parent_context: Context,
+    polymorphic_type: str,
+    relative_char_offset_start: int,
+    relative_char_offset_end: int,
+) -> str:
     """
     Contruct a stable ID for a Context given its parent and its character
     offsets relative to the parent.
@@ -17,7 +21,7 @@ def construct_stable_id(
     return f"{doc_id}::{polymorphic_type}:{start}:{end}"
 
 
-def split_stable_id(stable_id):
+def split_stable_id(stable_id: str) -> Tuple[str, str, int, int]:
     """Split stable id, returning:
 
         * Document (root) stable ID

--- a/src/fonduer/parser/models/webpage.py
+++ b/src/fonduer/parser/models/webpage.py
@@ -33,5 +33,5 @@ class Webpage(Context):
     __mapper_args__ = {"polymorphic_identity": "webpage"}
 
     # Rest of class definition here
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Webpage(id: {self.name[:10]}..., url: {self.url[8:23]}...)"

--- a/src/fonduer/parser/preprocessors/csv_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/csv_doc_preprocessor.py
@@ -1,6 +1,8 @@
 import codecs
 import csv
 import os
+import sys
+from typing import Callable, Dict, Iterator, Optional
 
 from fonduer.parser.models import Document
 from fonduer.parser.preprocessors.doc_preprocessor import DocPreprocessor
@@ -36,19 +38,19 @@ class CSVDocPreprocessor(DocPreprocessor):
 
     def __init__(
         self,
-        path,
-        encoding="utf-8",
-        max_docs=float("inf"),
-        header=False,
-        delim=",",
-        parser_rule=None,
-    ):
+        path: str,
+        encoding: str = "utf-8",
+        max_docs: int = sys.maxsize,
+        header: bool = False,
+        delim: str = ",",
+        parser_rule: Optional[Dict[int, Callable]] = None,
+    ) -> None:
         super(CSVDocPreprocessor, self).__init__(path, encoding, max_docs)
         self.header = header
         self.delim = delim
         self.parser_rule = parser_rule
 
-    def _parse_file(self, fp, file_name):
+    def _parse_file(self, fp: str, file_name: str) -> Iterator[Document]:
         name = os.path.basename(fp)[: os.path.basename(fp).rfind(".")]
         with codecs.open(fp, encoding=self.encoding) as f:
             reader = csv.reader(f)
@@ -86,7 +88,7 @@ class CSVDocPreprocessor(DocPreprocessor):
                     meta={"file_name": file_name},
                 )
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Provide a len attribute based on max_docs and number of rows in files."""
         cnt_docs = 0
         for fp in self.all_files:
@@ -98,5 +100,5 @@ class CSVDocPreprocessor(DocPreprocessor):
         num_docs = min(cnt_docs, self.max_docs)
         return num_docs
 
-    def _can_read(self, fpath):
+    def _can_read(self, fpath: str) -> bool:
         return fpath.lower().endswith(".csv")

--- a/src/fonduer/parser/preprocessors/doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/doc_preprocessor.py
@@ -1,6 +1,9 @@
 import glob
 import os
 import sys
+from typing import Iterator, List
+
+from fonduer.parser.models.document import Document
 
 
 class DocPreprocessor(object):
@@ -17,13 +20,15 @@ class DocPreprocessor(object):
     :rtype: A generator of ``Documents``.
     """
 
-    def __init__(self, path, encoding="utf-8", max_docs=sys.maxsize):
+    def __init__(
+        self, path: str, encoding: str = "utf-8", max_docs: int = sys.maxsize
+    ) -> None:
         self.path = path
         self.encoding = encoding
         self.max_docs = max_docs
         self.all_files = self._get_files(self.path)
 
-    def _generate(self):
+    def _generate(self) -> Iterator[Document]:
         """Parses a file or directory of files into a set of ``Document`` objects."""
         doc_count = 0
         for fp in self.all_files:
@@ -33,31 +38,31 @@ class DocPreprocessor(object):
                 if doc_count >= self.max_docs:
                     return
 
-    def __len__(self):
+    def __len__(self) -> int:
         raise NotImplementedError(
             "One generic file can yield more than one Document object, "
             "so length can not be yielded before we process all files"
         )
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Document]:
         return self._generate()
 
-    def _get_docs_for_path(self, fp):
+    def _get_docs_for_path(self, fp: str) -> Iterator[Document]:
         file_name = os.path.basename(fp)
         if self._can_read(file_name):
             for doc in self._parse_file(fp, file_name):
                 yield doc
 
-    def _get_stable_id(self, doc_id):
+    def _get_stable_id(self, doc_id: str) -> str:
         return f"{doc_id}::document:0:0"
 
-    def _parse_file(self, fp, file_name):
+    def _parse_file(self, fp: str, file_name: str) -> Iterator[Document]:
         raise NotImplementedError()
 
-    def _can_read(self, fpath):
+    def _can_read(self, fpath: str) -> bool:
         return not fpath.startswith(".")
 
-    def _get_files(self, path):
+    def _get_files(self, path: str) -> List[str]:
         if os.path.isfile(path):
             fpaths = [path]
         elif os.path.isdir(path):

--- a/src/fonduer/parser/preprocessors/html_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/html_doc_preprocessor.py
@@ -1,5 +1,6 @@
 import codecs
 import os
+from typing import Iterator
 
 from bs4 import BeautifulSoup
 
@@ -20,7 +21,7 @@ class HTMLDocPreprocessor(DocPreprocessor):
     :rtype: A generator of ``Documents``.
     """
 
-    def _parse_file(self, fp, file_name):
+    def _parse_file(self, fp: str, file_name: str) -> Iterator[Document]:
         with codecs.open(fp, encoding=self.encoding) as f:
             soup = BeautifulSoup(f, "lxml")
             all_html_elements = soup.find_all("html")
@@ -38,10 +39,10 @@ class HTMLDocPreprocessor(DocPreprocessor):
                 meta={"file_name": file_name},
             )
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Provide a len attribute based on max_docs and number of files in folder."""
         num_docs = min(len(self.all_files), self.max_docs)
         return num_docs
 
-    def _can_read(self, fpath):
+    def _can_read(self, fpath: str) -> bool:
         return fpath.lower().endswith("html")  # includes both .html and .xhtml

--- a/src/fonduer/parser/preprocessors/text_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/text_doc_preprocessor.py
@@ -1,5 +1,6 @@
 import codecs
 import os
+from typing import Iterator
 
 from fonduer.parser.models import Document
 from fonduer.parser.preprocessors.doc_preprocessor import DocPreprocessor
@@ -21,7 +22,7 @@ class TextDocPreprocessor(DocPreprocessor):
     :rtype: A generator of ``Documents``.
     """
 
-    def _parse_file(self, fp, file_name):
+    def _parse_file(self, fp: str, file_name: str) -> Iterator[Document]:
         with codecs.open(fp, encoding=self.encoding) as f:
             name = os.path.basename(fp).rsplit(".", 1)[0]
             stable_id = self._get_stable_id(name)
@@ -30,7 +31,7 @@ class TextDocPreprocessor(DocPreprocessor):
                 name=name, stable_id=stable_id, text=text, meta={"file_name": file_name}
             )
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Provide a len attribute based on max_docs and number of files in folder."""
         num_docs = min(len(self.all_files), self.max_docs)
         return num_docs

--- a/src/fonduer/parser/preprocessors/tsv_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/tsv_doc_preprocessor.py
@@ -1,4 +1,6 @@
 import codecs
+import sys
+from typing import Iterator
 
 from fonduer.parser.models import Document
 from fonduer.parser.preprocessors.doc_preprocessor import DocPreprocessor
@@ -22,11 +24,17 @@ class TSVDocPreprocessor(DocPreprocessor):
     :rtype: A generator of ``Documents``.
     """
 
-    def __init__(self, path, encoding="utf-8", max_docs=float("inf"), header=False):
+    def __init__(
+        self,
+        path: str,
+        encoding: str = "utf-8",
+        max_docs: int = sys.maxsize,
+        header: bool = False,
+    ) -> None:
         super(TSVDocPreprocessor, self).__init__(path, encoding, max_docs)
         self.header = header
 
-    def _parse_file(self, fp, file_name):
+    def _parse_file(self, fp: str, file_name: str) -> Iterator[Document]:
         with codecs.open(fp, encoding=self.encoding) as tsv:
             if self.header:
                 tsv.readline()
@@ -41,7 +49,7 @@ class TSVDocPreprocessor(DocPreprocessor):
                     meta={"file_name": file_name},
                 )
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Provide a len attribute based on max_docs and number of rows in files."""
         cnt_docs = 0
         for fp in self.all_files:
@@ -53,5 +61,5 @@ class TSVDocPreprocessor(DocPreprocessor):
         num_docs = min(cnt_docs, self.max_docs)
         return num_docs
 
-    def _can_read(self, fpath):
+    def _can_read(self, fpath: str) -> bool:
         return fpath.lower().endswith(".tsv")

--- a/src/fonduer/supervision/models/label.py
+++ b/src/fonduer/supervision/models/label.py
@@ -5,26 +5,26 @@ from fonduer.meta import Meta
 from fonduer.utils.models.annotation import AnnotationKeyMixin, AnnotationMixin
 
 
-class GoldLabelKey(AnnotationKeyMixin, Meta.Base):
+class GoldLabelKey(AnnotationKeyMixin, Meta.Base):  # type: ignore
     """A gold label's key that identifies the annotator of the gold label."""
 
     pass
 
 
-class GoldLabel(AnnotationMixin, Meta.Base):
+class GoldLabel(AnnotationMixin, Meta.Base):  # type: ignore
     """A separate class for labels from human annotators or other gold standards."""
 
     #: A list of integer values for each Key.
     values = Column(postgresql.ARRAY(Integer), nullable=False)
 
 
-class LabelKey(AnnotationKeyMixin, Meta.Base):
+class LabelKey(AnnotationKeyMixin, Meta.Base):  # type: ignore
     """A label's key that identifies the labeling function."""
 
     pass
 
 
-class Label(AnnotationMixin, Meta.Base):
+class Label(AnnotationMixin, Meta.Base):  # type: ignore
     """
     A discrete label associated with a Candidate, indicating a target prediction value.
 
@@ -36,7 +36,7 @@ class Label(AnnotationMixin, Meta.Base):
     values = Column(postgresql.ARRAY(Integer), nullable=False)
 
 
-class StableLabel(Meta.Base):
+class StableLabel(Meta.Base):  # type: ignore
     """
     A special secondary table for preserving labels created by *human
     annotators* in a stable format that does not cascade, and is independent of


### PR DESCRIPTION
This patch annotates types to some of the class methods.
I'd like to do type annotations one by one instead of a one single big pull-request because 1. it is hard to review a big pull-request and 2. type annotations would require impl code changes sometimes, which makes the code review even harder.
Type checks is now possible by the following commands but currently not enforced until all the types are annotated.

```bash
$ make dev
$ mypy src/
$ mypy tests/
```