### PR TITLE
Allow creating a mention/candidate subclass even before Meta is initialized

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -82,6 +82,8 @@ Fixed
 * `@HiromuHota`_: Fix the type of max_docs.
 * `@HiromuHota`_: Associate sentence with section and paragraph no matter what tabular is.
   (`#261 <https://github.com/HazyResearch/fonduer/pull/261>`_)
+* `@HiromuHota`_: Add a safeguard that prevents from accessing Meta.engine before it is assigned.
+  Also this change allows creating a mention/candidate subclass even before Meta is initialized.
 
 0.7.0_ - 2019-06-12
 -------------------

--- a/src/fonduer/candidates/models/candidate.py
+++ b/src/fonduer/candidates/models/candidate.py
@@ -187,7 +187,7 @@ def candidate_subclass(
         C = type(class_name, (Candidate,), class_attribs)
 
         # Create table in DB
-        if not Meta.engine.dialect.has_table(Meta.engine, table_name):
+        if Meta.engine and not Meta.engine.has_table(table_name):
             C.__table__.create(bind=Meta.engine)
 
         candidate_subclasses[class_name] = C, class_spec

--- a/src/fonduer/candidates/models/mention.py
+++ b/src/fonduer/candidates/models/mention.py
@@ -169,7 +169,7 @@ def mention_subclass(
         C = type(class_name, (Mention,), class_attribs)
 
         # Create table in DB
-        if not Meta.engine.dialect.has_table(Meta.engine, table_name):
+        if Meta.engine and not Meta.engine.has_table(table_name):
             C.__table__.create(bind=Meta.engine)
 
         mention_subclasses[class_name] = C, class_spec

--- a/tests/candidates/test_candidates.py
+++ b/tests/candidates/test_candidates.py
@@ -633,3 +633,17 @@ def test_multimodal_cand(caplog):
     assert session.query(ms_para).count() == 30
     assert session.query(ms_sent).count() == 35
     assert session.query(ms_cell).count() == 21
+
+
+def test_subclass_before_meta_init(caplog):
+    """Test if it is possible to create a mention (candidate) subclass even before Meta
+    is initialized.
+    """
+    caplog.set_level(logging.INFO)
+
+    conn_string = "postgresql://localhost:5432/" + DB
+    Part = mention_subclass("Part")
+    logger.info(f"Create a mention subclass '{Part.__tablename__}'")
+    Meta.init(conn_string).Session()
+    Temp = mention_subclass("Temp")
+    logger.info(f"Create a mention subclass '{Temp.__tablename__}'")


### PR DESCRIPTION
Currently, a mention/candidate subclass can be created **only after** `Meta` gets initialized.

Works: 
```python
Meta.init(conn_string).Session()
Part = mention_subclass("Part")
```

Not work:
```python
Part = mention_subclass("Part")
Meta.init(conn_string).Session()
```

This PR removes such an order dependency and allows creating a mention/candidate subclass even before it is initialized.