### PR TITLE
super() to access the super class for simplicity and error-free

### DIFF
--- a/src/fonduer/candidates/candidates.py
+++ b/src/fonduer/candidates/candidates.py
@@ -68,7 +68,7 @@ class CandidateExtractor(UDFRunner):
             throttlers = [None] * len(candidate_classes)
 
         """Initialize the CandidateExtractor."""
-        super(CandidateExtractor, self).__init__(
+        super().__init__(
             session,
             CandidateExtractorUDF,
             parallelism=parallelism,
@@ -115,7 +115,7 @@ class CandidateExtractor(UDFRunner):
             progress bar is measured per document.
         :type progress_bar: bool
         """
-        super(CandidateExtractor, self).apply(
+        super().apply(
             docs,
             split=split,
             clear=clear,
@@ -241,7 +241,7 @@ class CandidateExtractorUDF(UDF):
         self.symmetric_relations = symmetric_relations
         self.arities = [len(cclass.__argnames__) for cclass in self.candidate_classes]
 
-        super(CandidateExtractorUDF, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def apply(
         self, context: Document, clear: bool, split: int, **kwargs: Any

--- a/src/fonduer/candidates/matchers.py
+++ b/src/fonduer/candidates/matchers.py
@@ -388,7 +388,7 @@ class PersonMatcher(RegexMatchEach):
     def __init__(self, *children, **kwargs):  # type: ignore
         kwargs["attrib"] = "ner_tags"
         kwargs["rgx"] = "PERSON"
-        super(PersonMatcher, self).__init__(*children, **kwargs)
+        super().__init__(*children, **kwargs)
 
 
 class LocationMatcher(RegexMatchEach):
@@ -402,7 +402,7 @@ class LocationMatcher(RegexMatchEach):
     def __init__(self, *children, **kwargs):  # type: ignore
         kwargs["attrib"] = "ner_tags"
         kwargs["rgx"] = "GPE|LOC"
-        super(LocationMatcher, self).__init__(*children, **kwargs)
+        super().__init__(*children, **kwargs)
 
 
 class OrganizationMatcher(RegexMatchEach):
@@ -416,7 +416,7 @@ class OrganizationMatcher(RegexMatchEach):
     def __init__(self, *children, **kwargs):  # type: ignore
         kwargs["attrib"] = "ner_tags"
         kwargs["rgx"] = "NORG|ORG"
-        super(OrganizationMatcher, self).__init__(*children, **kwargs)
+        super().__init__(*children, **kwargs)
 
 
 class DateMatcher(RegexMatchEach):
@@ -430,7 +430,7 @@ class DateMatcher(RegexMatchEach):
     def __init__(self, *children, **kwargs):  # type: ignore
         kwargs["attrib"] = "ner_tags"
         kwargs["rgx"] = "DATE"
-        super(DateMatcher, self).__init__(*children, **kwargs)
+        super().__init__(*children, **kwargs)
 
 
 class NumberMatcher(RegexMatchEach):
@@ -444,7 +444,7 @@ class NumberMatcher(RegexMatchEach):
     def __init__(self, *children, **kwargs):  # type: ignore
         kwargs["attrib"] = "ner_tags"
         kwargs["rgx"] = "NUMBER|QUANTITY"
-        super(NumberMatcher, self).__init__(*children, **kwargs)
+        super().__init__(*children, **kwargs)
 
 
 class MiscMatcher(RegexMatchEach):
@@ -458,7 +458,7 @@ class MiscMatcher(RegexMatchEach):
     def __init__(self, *children, **kwargs):  # type: ignore
         kwargs["attrib"] = "ner_tags"
         kwargs["rgx"] = "MISC"
-        super(MiscMatcher, self).__init__(*children, **kwargs)
+        super().__init__(*children, **kwargs)
 
 
 class LambdaFunctionFigureMatcher(_Matcher):

--- a/src/fonduer/candidates/mentions.py
+++ b/src/fonduer/candidates/mentions.py
@@ -411,7 +411,7 @@ class MentionExtractor(UDFRunner):
         parallelism: int = 1,
     ):
         """Initialize the MentionExtractor."""
-        super(MentionExtractor, self).__init__(
+        super().__init__(
             session,
             MentionExtractorUDF,
             parallelism=parallelism,
@@ -456,7 +456,7 @@ class MentionExtractor(UDFRunner):
             progress bar is measured per document.
         :type progress_bar: bool
         """
-        super(MentionExtractor, self).apply(
+        super().apply(
             docs, clear=clear, parallelism=parallelism, progress_bar=progress_bar
         )
 
@@ -566,7 +566,7 @@ class MentionExtractorUDF(UDF):
         # Preallocates internal data structure
         self.child_context_set: Set[TemporaryContext] = set()
 
-        super(MentionExtractorUDF, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def apply(self, doc: Document, clear: bool, **kwargs: Any) -> Iterator[Mention]:
         """Extract mentions from the given Document.

--- a/src/fonduer/candidates/models/caption_mention.py
+++ b/src/fonduer/candidates/models/caption_mention.py
@@ -12,7 +12,7 @@ class TemporaryCaptionMention(TemporaryContext):
     """The TemporaryContext version of CaptionMention."""
 
     def __init__(self, caption: Caption) -> None:
-        super(TemporaryCaptionMention, self).__init__()
+        super().__init__()
         self.caption = caption  # The caption Context
 
     def __len__(self) -> int:

--- a/src/fonduer/candidates/models/cell_mention.py
+++ b/src/fonduer/candidates/models/cell_mention.py
@@ -12,7 +12,7 @@ class TemporaryCellMention(TemporaryContext):
     """The TemporaryContext version of CellMention."""
 
     def __init__(self, cell: Cell) -> None:
-        super(TemporaryCellMention, self).__init__()
+        super().__init__()
         self.cell = cell  # The cell Context
 
     def __len__(self) -> int:

--- a/src/fonduer/candidates/models/document_mention.py
+++ b/src/fonduer/candidates/models/document_mention.py
@@ -12,7 +12,7 @@ class TemporaryDocumentMention(TemporaryContext):
     """The TemporaryContext version of DocumentMention."""
 
     def __init__(self, document: Document) -> None:
-        super(TemporaryDocumentMention, self).__init__()
+        super().__init__()
         self.document = document  # The document Context
 
     def __len__(self) -> int:

--- a/src/fonduer/candidates/models/figure_mention.py
+++ b/src/fonduer/candidates/models/figure_mention.py
@@ -12,7 +12,7 @@ class TemporaryFigureMention(TemporaryContext):
     """The TemporaryContext version of FigureMention."""
 
     def __init__(self, figure: Figure) -> None:
-        super(TemporaryFigureMention, self).__init__()
+        super().__init__()
         self.figure = figure  # The figure Context
 
     def __len__(self) -> int:

--- a/src/fonduer/candidates/models/implicit_span_mention.py
+++ b/src/fonduer/candidates/models/implicit_span_mention.py
@@ -36,10 +36,7 @@ class TemporaryImplicitSpanMention(TemporarySpanMention):
         right: List[Optional[int]],
         meta: Any = None,
     ) -> None:
-        super(TemporarySpanMention, self).__init__()
-        self.sentence = sentence  # The sentence Context of the Span
-        self.char_start = char_start
-        self.char_end = char_end
+        super().__init__(sentence, char_start, char_end, meta)
         self.expander_key = expander_key
         self.position = position
         self.text = text
@@ -54,7 +51,6 @@ class TemporaryImplicitSpanMention(TemporarySpanMention):
         self.left = left
         self.bottom = bottom
         self.right = right
-        self.meta = meta
 
     def __len__(self) -> int:
         return sum(map(len, self.words))

--- a/src/fonduer/candidates/models/paragraph_mention.py
+++ b/src/fonduer/candidates/models/paragraph_mention.py
@@ -12,7 +12,7 @@ class TemporaryParagraphMention(TemporaryContext):
     """The TemporaryContext version of ParagraphMention."""
 
     def __init__(self, paragraph: Paragraph) -> None:
-        super(TemporaryParagraphMention, self).__init__()
+        super().__init__()
         self.paragraph = paragraph  # The paragraph Context
 
     def __len__(self) -> int:

--- a/src/fonduer/candidates/models/section_mention.py
+++ b/src/fonduer/candidates/models/section_mention.py
@@ -12,7 +12,7 @@ class TemporarySectionMention(TemporaryContext):
     """The TemporaryContext version of SectionMention."""
 
     def __init__(self, section: Section) -> None:
-        super(TemporarySectionMention, self).__init__()
+        super().__init__()
         self.section = section  # The section Context
 
     def __len__(self) -> int:

--- a/src/fonduer/candidates/models/span_mention.py
+++ b/src/fonduer/candidates/models/span_mention.py
@@ -20,7 +20,7 @@ class TemporarySpanMention(TemporaryContext):
         char_end: int,
         meta: Optional[Any] = None,
     ) -> None:
-        super(TemporarySpanMention, self).__init__()
+        super().__init__()
         self.sentence = sentence  # The sentence Context of the Span
         self.char_start = char_start
         self.char_end = char_end

--- a/src/fonduer/candidates/models/table_mention.py
+++ b/src/fonduer/candidates/models/table_mention.py
@@ -12,7 +12,7 @@ class TemporaryTableMention(TemporaryContext):
     """The TemporaryContext version of TableMention."""
 
     def __init__(self, table: Table) -> None:
-        super(TemporaryTableMention, self).__init__()
+        super().__init__()
         self.table = table  # The table Context
 
     def __len__(self) -> int:

--- a/src/fonduer/features/featurizer.py
+++ b/src/fonduer/features/featurizer.py
@@ -44,7 +44,7 @@ class Featurizer(UDFRunner):
         parallelism: int = 1,
     ) -> None:
         """Initialize the Featurizer."""
-        super(Featurizer, self).__init__(
+        super().__init__(
             session,
             FeaturizerUDF,
             parallelism=parallelism,
@@ -117,7 +117,7 @@ class Featurizer(UDFRunner):
         if docs:
             # Call apply on the specified docs for all splits
             split = ALL_SPLITS
-            super(Featurizer, self).apply(
+            super().apply(
                 docs,
                 split=split,
                 train=train,
@@ -132,7 +132,7 @@ class Featurizer(UDFRunner):
             split_docs = get_docs_from_split(
                 self.session, self.candidate_classes, split
             )
-            super(Featurizer, self).apply(
+            super().apply(
                 split_docs,
                 split=split,
                 train=train,
@@ -308,7 +308,7 @@ class FeaturizerUDF(UDF):
 
         self.feature_extractors = feature_extractors
 
-        super(FeaturizerUDF, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def apply(
         self, doc: Document, split: int, train: bool, **kwargs: Any

--- a/src/fonduer/learning/classifier.py
+++ b/src/fonduer/learning/classifier.py
@@ -31,7 +31,7 @@ class Classifier(nn.Module):
     _collate = default_collate
 
     def __init__(self, name=None):
-        nn.Module.__init__(self)
+        super().__init__()
         self.logger = logging.getLogger(__name__)
         self.name = name or self.__class__.__name__
         self.tensorboard_logger = None

--- a/src/fonduer/learning/disc_models/modules/rnn.py
+++ b/src/fonduer/learning/disc_models/modules/rnn.py
@@ -42,7 +42,7 @@ class RNN(nn.Module):
         use_cuda=False,
     ):
 
-        super(RNN, self).__init__()
+        super().__init__()
 
         self.num_tokens = num_tokens
         self.emb_size = emb_size

--- a/src/fonduer/learning/disc_models/modules/sparse_linear.py
+++ b/src/fonduer/learning/disc_models/modules/sparse_linear.py
@@ -23,7 +23,7 @@ class SparseLinear(nn.Module):
 
     def __init__(self, num_features, num_classes, bias=False, padding_idx=0):
 
-        super(SparseLinear, self).__init__()
+        super().__init__()
 
         self.num_features = num_features
         self.num_classes = num_classes

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -81,7 +81,7 @@ class Parser(UDFRunner):
         vizlink: Optional[VisualLinker] = None,  # visual linker
         pdf_path: Optional[str] = None,
     ) -> None:
-        super(Parser, self).__init__(
+        super().__init__(
             session,
             ParserUDF,
             parallelism=parallelism,
@@ -124,7 +124,7 @@ class Parser(UDFRunner):
             progress bar is measured per document.
         :type progress_bar: bool
         """
-        super(Parser, self).apply(
+        super().apply(
             doc_loader,
             pdf_path=pdf_path,
             clear=clear,
@@ -186,7 +186,7 @@ class ParserUDF(UDF):
             All occurents of _pattern_ in the text will be replaced by
             _replace_.
         """
-        super(ParserUDF, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # structural (html) setup
         self.structural = structural

--- a/src/fonduer/parser/preprocessors/csv_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/csv_doc_preprocessor.py
@@ -45,7 +45,7 @@ class CSVDocPreprocessor(DocPreprocessor):
         delim: str = ",",
         parser_rule: Optional[Dict[int, Callable]] = None,
     ) -> None:
-        super(CSVDocPreprocessor, self).__init__(path, encoding, max_docs)
+        super().__init__(path, encoding, max_docs)
         self.header = header
         self.delim = delim
         self.parser_rule = parser_rule

--- a/src/fonduer/parser/preprocessors/tsv_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/tsv_doc_preprocessor.py
@@ -31,7 +31,7 @@ class TSVDocPreprocessor(DocPreprocessor):
         max_docs: int = sys.maxsize,
         header: bool = False,
     ) -> None:
-        super(TSVDocPreprocessor, self).__init__(path, encoding, max_docs)
+        super().__init__(path, encoding, max_docs)
         self.header = header
 
     def _parse_file(self, fp: str, file_name: str) -> Iterator[Document]:

--- a/src/fonduer/supervision/labeler.py
+++ b/src/fonduer/supervision/labeler.py
@@ -31,7 +31,7 @@ class Labeler(UDFRunner):
 
     def __init__(self, session, candidate_classes, parallelism=1):
         """Initialize the Labeler."""
-        super(Labeler, self).__init__(
+        super().__init__(
             session,
             LabelerUDF,
             parallelism=parallelism,
@@ -122,7 +122,7 @@ class Labeler(UDFRunner):
         if docs:
             # Call apply on the specified docs for all splits
             split = ALL_SPLITS
-            super(Labeler, self).apply(
+            super().apply(
                 docs,
                 split=split,
                 train=train,
@@ -138,7 +138,7 @@ class Labeler(UDFRunner):
             split_docs = get_docs_from_split(
                 self.session, self.candidate_classes, split
             )
-            super(Labeler, self).apply(
+            super().apply(
                 split_docs,
                 split=split,
                 train=train,
@@ -319,7 +319,7 @@ class LabelerUDF(UDF):
             if isinstance(candidate_classes, (list, tuple))
             else [candidate_classes]
         )
-        super(LabelerUDF, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def _f_gen(self, c):
         """Convert lfs into a generator of id, name, and labels.

--- a/src/fonduer/utils/udf.py
+++ b/src/fonduer/utils/udf.py
@@ -190,7 +190,7 @@ class UDF(Process):
         """
         in_queue: A Queue of input objects to process; primarily for running in parallel
         """
-        Process.__init__(self)
+        super().__init__()
         self.daemon = True
         self.in_queue = in_queue
         self.out_queue = out_queue

--- a/tests/shared/hardware_spaces.py
+++ b/tests/shared/hardware_spaces.py
@@ -172,7 +172,7 @@ class MentionNgramsPart(MentionNgrams):
         :param parts_by_doc: a dictionary d where d[document_name.upper()] =
             [partA, partB, ...]
         """
-        super(MentionNgrams, self).__init__(n_max=n_max, split_tokens=split_tokens)
+        super().__init__(n_max=n_max, split_tokens=split_tokens)
         self.parts_by_doc = parts_by_doc
         self.expander = expand_part_range if expand else (lambda x: [x])
 
@@ -228,7 +228,7 @@ class MentionNgramsPart(MentionNgrams):
 
 class MentionNgramsTemp(MentionNgrams):
     def __init__(self, n_max=2, split_tokens=["-", "/"]):
-        super(MentionNgrams, self).__init__(n_max=n_max, split_tokens=split_tokens)
+        super().__init__(n_max=n_max, split_tokens=split_tokens)
 
     def apply(self, doc):
         for ts in MentionNgrams.apply(self, doc):
@@ -287,7 +287,7 @@ class MentionNgramsTemp(MentionNgrams):
 
 class MentionNgramsVolt(MentionNgrams):
     def __init__(self, n_max=1, split_tokens=["-", "/"]):
-        super(MentionNgrams, self).__init__(n_max=n_max, split_tokens=split_tokens)
+        super().__init__(n_max=n_max, split_tokens=split_tokens)
 
     def apply(self, doc):
         for ts in MentionNgrams.apply(self, doc):


### PR DESCRIPTION
The parameterless `super()` syntax is available on Python 3.
This is more error-free because you don't have to specify subclass name like `super(SubClass, self).__init()`.
In fact, the current below code is wrong:

```
class TemporaryImplicitSpanMention(TemporarySpanMention):
    def __init__(self, ...)
        super(TemporarySpanMention, self).__init__()
```
https://github.com/hazyresearch/fonduer/blob/master/src/fonduer/candidates/models/implicit_span_mention.py#L39

By using `super()`, we can avoid such an error.

Note that this is just a code cleanup hence not worth being mentioned in CHANGELOG.