### PR TITLE
Optimize conda operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,9 @@ before_install:
 - bash miniconda.sh -b -p $HOME/miniconda
 - export PATH="$HOME/miniconda/bin:$PATH"
 - conda config --set always_yes yes --set changeps1 no
-- conda update -q conda
-- conda install -q conda-build
-- conda install -q -c conda-forge poppler
 - conda create -q -n test-environment python=${PYTHON}
 - source activate test-environment
+- conda install -q -c conda-forge poppler
 - conda install -q pip
 
 - pdfinfo -v


### PR DESCRIPTION
1. conda is good to be up-to-date, but not needed.
1. conda-build is no longer needed as poppler is no longer built from source.
1. Installing poppler after switching to an env reduces duplicate installations of dependencies (e.g., currently `certifi` is installed once on Python 3.7 and one more time on Python 3.6).