### PR TITLE
Use the official name "beautifulsoup4" instead of an alias "bs4"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,6 +71,8 @@ Changed
 * `@HiromuHota`_: Add a unit test for ``Parser`` with tabular=False.
   (`#261 <https://github.com/HazyResearch/fonduer/pull/261>`_)
 * `@HiromuHota`_: Now ``longest_match_only`` of ``Union``, ``Intersect``, and ``Inverse`` override that of child matchers.
+* `@HiromuHota`_: Use the official name "beautifulsoup4" instead of an alias "bs4".
+  (`#306 <https://github.com/HazyResearch/fonduer/issues/306>`_)
 
 Removed
 ^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     package_dir={"": "src"},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     install_requires=[
-        "bs4>=0.0.1, <0.1.0",
+        "beautifulsoup4==4.7.1",
         "editdistance>=0.5.2, <0.6.0",
         "lxml>=4.2.5, <5.0.0",
         "numpy>=1.11, <2.0",


### PR DESCRIPTION
This will resolve #306.

The latest version of beautifulsoup4 is now 4.8.0.
Though I couldn't find any breaking changes at 4.8.0 as far as [CHANGELOG](https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/CHANGELOG) is concerned, let's stay 4.7.1 for now.
If you are confident to include 4.8.0 and higher, please let me know.