### PR TITLE
Use pytorch of 1.2.0 for Travis and Docker for simpler installation (than 1.1.0 and lower)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,12 +67,7 @@ before_install:
 # Install PyTorch for Linux with no CUDA support
 - |
   if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    if [ "${PYTHON}" = "3.6" ]; then
-      pip install https://download.pytorch.org/whl/cpu/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
-    fi
-    if [ "${PYTHON}" = "3.7" ]; then
-      pip install https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-linux_x86_64.whl
-    fi
+    pip install torch==1.2.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
     pip install Wand
     sudo apt-get install libmagickwand-dev ghostscript
     sudo rm -rf /etc/ImageMagick-6/policy.xml

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -73,6 +73,7 @@ Changed
 * `@HiromuHota`_: Now ``longest_match_only`` of ``Union``, ``Intersect``, and ``Inverse`` override that of child matchers.
 * `@HiromuHota`_: Use the official name "beautifulsoup4" instead of an alias "bs4".
   (`#306 <https://github.com/HazyResearch/fonduer/issues/306>`_)
+* `@HiromuHota`_: Use pytorch of 1.2.0 for Travis and Docker for simpler installation (than 1.1.0 and lower).
 
 Removed
 ^^^^^^^

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,5 @@ ARG FONDUER_VERSION=
 # Set --build-arg FONDUER_VERSION=0.7.0 to install a specific version of Fonduer,
 # otherwise the lastest version is installed.
 RUN pip install \
-    https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-linux_x86_64.whl \
+    torch==1.2.0+cpu -f https://download.pytorch.org/whl/torch_stable.html \
     fonduer${FONDUER_VERSION:+==${FONDUER_VERSION}}


### PR DESCRIPTION
PyTorch became simpler to install at 1.2.0
https://github.com/pytorch/pytorch/releases

> Wheels that are for non-default CUDA configurations (the default CUDA version for this release is 10.0) now have local version identifiers like +cpu and +cu92. This means that, when installing, it is no longer necessary to specify a full wheel URL—just specify an appropriate version constraint like torch==1.2.0+cu92.

This patch makes the use of this improvement.