### PR TITLE
Enable test_visualizer on mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,19 @@ before_install:
     # No need to adjust it on Mac as it's 100 by default
     sudo sed -i 's/max_connections = 255/max_connections = 100/g' /etc/postgresql/10/main/postgresql.conf
     sudo service postgresql restart
+    # Install ImageMagick library for Wand
+    sudo apt-get install libmagickwand-dev ghostscript
+    sudo rm -rf /etc/ImageMagick-6/policy.xml
   else
     OS=MacOSX-x86_64
     brew update
     brew install swig mecab mecab-unidic
     brew install libomp  # https://github.com/pytorch/pytorch/issues/20030
     sed -i -e "s/ipadic/unidic/" /usr/local/etc/mecabrc
+    # Install ImageMagick library for Wand
+    brew install freetype imagemagick@6 ghostscript
+    # https://stackoverflow.com/a/41772062
+    ln -s `brew info imagemagick@6 | grep ^/usr | awk '{print $1}'`/lib/libMagickWand-6.Q16.dylib /usr/local/lib/libMagickWand.dylib
     # Start postgresql for osx
     rm -rf /usr/local/var/postgres
     initdb /usr/local/var/postgres
@@ -77,9 +84,6 @@ before_install:
     if [ "${PYTHON}" = "3.7" ]; then
       pip install https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-linux_x86_64.whl
     fi
-    pip install Wand
-    sudo apt-get install libmagickwand-dev ghostscript
-    sudo rm -rf /etc/ImageMagick-6/policy.xml
   fi
 
 install:

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -17,6 +17,7 @@ For OS X using homebrew_::
     $ brew install postgresql
     $ brew install libpng freetype pkg-config
     $ brew install libomp #https://github.com/pytorch/pytorch/issues/20030
+    $ brew install imagemagick@6
 
 On Debian-based distros::
 
@@ -25,6 +26,7 @@ On Debian-based distros::
     $ sudo apt build-dep python-matplotlib
     $ sudo apt install poppler-utils
     $ sudo apt install postgresql
+    $ sudo apt install libmagickwand-dev
 
 .. note::
     Fonduer recommends using PostgreSQL version 9.6 or later.
@@ -33,6 +35,9 @@ On Debian-based distros::
     Fonduer requires ``poppler-utils`` to be version 0.36.0 or later.
     Otherwise, the ``-bbox-layout`` option is not available for ``pdftotext``
     (`see changelog`_).
+
+.. note::
+    Fonduer depends on Wand (>=0.4.4, <0.5.0), which does not support ImageMagick7.
 
 Installing the Fonduer Package
 ------------------------------

--- a/tests/utils/test_visualizer.py
+++ b/tests/utils/test_visualizer.py
@@ -5,9 +5,6 @@ visualizer_test has been created for the purpose of testing.
 If you are testing locally, you will need to create this db.
 """
 import logging
-import sys
-
-import pytest
 
 from fonduer import Meta
 from fonduer.candidates import CandidateExtractor, MentionExtractor, MentionNgrams
@@ -20,9 +17,6 @@ from fonduer.parser.preprocessors import HTMLDocPreprocessor
 ATTRIBUTE = "visualizer_test"
 
 
-@pytest.mark.skipif(
-    sys.platform == "darwin", reason="Only run visualizer test on Linux"
-)
 def test_visualizer(caplog):
     from fonduer.utils.visualizer import Visualizer  # noqa
 
@@ -75,10 +69,6 @@ def test_visualizer(caplog):
     vis.display_candidates([cands[0]])
 
 
-# TODO test on MacOSX too
-@pytest.mark.skipif(
-    sys.platform == "darwin", reason="Only run visualizer test on Linux"
-)
 def test_get_pdf_dim(caplog):
     from fonduer.utils.visualizer import get_pdf_dim  # noqa
 


### PR DESCRIPTION
Fonduer depends on Wand (>=0.4.4, <0.5.0), which does not support ImageMagick7, while Homebrew install ImageMagick7 unless you specify `imagemagick@6`.