### PR TITLE
Fix `featurizer.apply(docs=train_docs)` fails on clearing (fix #250)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -94,6 +94,8 @@ Fixed
   Also this change allows creating a mention/candidate subclass even before Meta is initialized.
 * `@HiromuHota`_: Create an Engine and open a connection in each child process.
   (`#323 <https://github.com/HazyResearch/fonduer/issues/323>`_)
+* `@HiromuHota`_: Fix ``featurizer.apply(docs=train_docs)`` fails on clearing.
+  (`#250 <https://github.com/HazyResearch/fonduer/issues/250>`_)
 
 0.7.0_ - 2019-06-12
 -------------------

--- a/src/fonduer/features/featurizer.py
+++ b/src/fonduer/features/featurizer.py
@@ -259,9 +259,14 @@ class Featurizer(UDFRunner):
         # Clear Features for the candidates in the split passed in.
         logger.info(f"Clearing Features (split {split})")
 
-        sub_query = (
-            self.session.query(Candidate.id).filter(Candidate.split == split).subquery()
-        )
+        if split == ALL_SPLITS:
+            sub_query = self.session.query(Candidate.id).subquery()
+        else:
+            sub_query = (
+                self.session.query(Candidate.id)
+                .filter(Candidate.split == split)
+                .subquery()
+            )
         query = self.session.query(Feature).filter(Feature.candidate_id.in_(sub_query))
         query.delete(synchronize_session="fetch")
 

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -70,7 +70,7 @@ def test_feature_extraction(caplog):
     featurizer = Featurizer(session, [PartTemp])
 
     # Test that featurization default feature library
-    featurizer.apply(split=0, train=True, parallelism=PARALLEL)
+    featurizer.apply(docs=docs, train=True, parallelism=PARALLEL)
     n_default_feats = session.query(FeatureKey).count()
     featurizer.clear(train=True)
 

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -70,7 +70,7 @@ def test_feature_extraction(caplog):
     featurizer = Featurizer(session, [PartTemp])
 
     # Test that featurization default feature library
-    featurizer.apply(docs=docs, train=True, parallelism=PARALLEL)
+    featurizer.apply(split=0, train=True, parallelism=PARALLEL)
     n_default_feats = session.query(FeatureKey).count()
     featurizer.clear(train=True)
 


### PR DESCRIPTION
More commits are coming.
The first commit reproduce #250.
Upcoming commits fix it.