### PR TITLE
Fix deadlock error during Labeler.apply and Featurizer.apply

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -100,6 +100,7 @@ Fixed
   (`#332 <https://github.com/HazyResearch/fonduer/issues/332>`_)
 * `@HiromuHota`_: Fix deadlock error during Labeler.apply and Featurizer.apply.
   (`#328 <https://github.com/HazyResearch/fonduer/issues/328>`_)
+* `@HiromuHota`_: Avoid networkx 2.4 so that snorkel-metal does not use the removed API.
 
 0.7.0_ - 2019-06-12
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -98,6 +98,8 @@ Fixed
   (`#250 <https://github.com/HazyResearch/fonduer/issues/250>`_)
 * `@HiromuHota`_: Correct abs_char_offsets to make it absolute.
   (`#332 <https://github.com/HazyResearch/fonduer/issues/332>`_)
+* `@HiromuHota`_: Fix deadlock error during Labeler.apply and Featurizer.apply.
+  (`#328 <https://github.com/HazyResearch/fonduer/issues/328>`_)
 
 0.7.0_ - 2019-06-12
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "pyyaml>=4.2b1, <5.0",
         "scipy>=1.1.0, <2.0.0",
         "snorkel-metal>=0.4.1, <0.5.0",
+        "networkx>=2.2, <2.4",
         "spacy>=2.1.3, <2.2.0",
         "sqlalchemy[postgresql_psycopg2binary]>=1.2.12, <2.0.0",
         "tensorboardX>=1.6, <2.0",

--- a/src/fonduer/features/featurizer.py
+++ b/src/fonduer/features/featurizer.py
@@ -1,7 +1,7 @@
 import itertools
 import logging
 from collections import defaultdict
-from typing import Any, Collection, Dict, Iterable, Iterator, List, Optional, Type
+from typing import Any, Collection, Iterable, Iterator, List, Optional, Type
 
 from scipy.sparse import csr_matrix
 from sqlalchemy.orm import Session
@@ -342,18 +342,12 @@ class FeaturizerUDF(UDF):
             self.session, self.candidate_classes, doc, split
         )
 
-        feature_map: Dict = dict()
-
         # Make a flat list of all candidates from the list of list of
         # candidates. This helps reduce the number of queries needed to update.
         all_cands = itertools.chain.from_iterable(cands_list)
         records = list(
             get_mapping(
-                self.session,
-                Feature,
-                all_cands,
-                self.feature_extractors.extract,
-                feature_map,
+                self.session, Feature, all_cands, self.feature_extractors.extract
             )
         )
         batch_upsert_records(self.session, Feature, records)

--- a/src/fonduer/supervision/labeler.py
+++ b/src/fonduer/supervision/labeler.py
@@ -382,11 +382,8 @@ class LabelerUDF(UDF):
             self.session, self.candidate_classes, doc, split
         )
 
-        label_map = dict()
         for cands in cands_list:
-            records = list(
-                get_mapping(self.session, Label, cands, self._f_gen, label_map)
-            )
+            records = list(get_mapping(self.session, Label, cands, self._f_gen))
             batch_upsert_records(self.session, Label, records)
 
         # This return + yield makes a completely empty generator

--- a/src/fonduer/utils/udf.py
+++ b/src/fonduer/utils/udf.py
@@ -90,9 +90,16 @@ class UDFRunner(object):
             self.logger.debug("Closing progress bar...")
             self.pb.close()
 
+        self.logger.debug("Running after_apply...")
+        self.after_apply(**kwargs)
+
     def clear(self, **kwargs: Any) -> None:
         """Clear the associated data from the database."""
         raise NotImplementedError()
+
+    def after_apply(self, **kwargs: Any) -> None:
+        """This method is executed by a single process after apply."""
+        pass
 
     def _apply_st(self, doc_loader: Collection[Document], **kwargs: Any) -> None:
         """Run the UDF single-threaded, optionally with progress bar"""

--- a/src/fonduer/utils/utils_udf.py
+++ b/src/fonduer/utils/utils_udf.py
@@ -189,7 +189,6 @@ def get_mapping(
     table: Table,
     candidates: Iterable[Candidate],
     generator: Callable[[List[Candidate]], Iterator[Tuple]],
-    key_map: Dict[Any, Any],
 ) -> Iterator[Dict[str, Any]]:
     """Generate map of keys and values for the candidate from the generator.
 
@@ -197,9 +196,6 @@ def get_mapping(
     :param table: The table we will be inserting into (i.e. Feature or Label).
     :param candidates: The candidates to get mappings for.
     :param generator: A generator yielding (candidate_id, key, value) tuples.
-    :param key_map: A mutable dict which values will be added to as {key:
-        [relations]}.
-    :type key_map: Dict
     :return: Generator of dictionaries of {"candidate_id": _, "keys": _, "values": _}
     :rtype: generator of dict
     """
@@ -221,12 +217,6 @@ def get_mapping(
         map_args["keys"] = [*cand_map.keys()]
         map_args["values"] = [*cand_map.values()]
 
-        # Update key_map by adding the candidate class for each key
-        for key in map_args["keys"]:
-            try:
-                key_map[key].add(cand.__class__.__tablename__)
-            except KeyError:
-                key_map[key] = {cand.__class__.__tablename__}
         yield map_args
 
 

--- a/src/fonduer/utils/utils_udf.py
+++ b/src/fonduer/utils/utils_udf.py
@@ -207,17 +207,17 @@ def get_mapping(
         except NoResultFound:
             cand_map = {}
 
-        map_args = {"candidate_id": cand.id}
         for cid, key, value in generator(cand):
             if value == 0:
                 continue
             cand_map[key] = value
 
         # Assemble label arguments
-        map_args["keys"] = [*cand_map.keys()]
-        map_args["values"] = [*cand_map.values()]
-
-        yield map_args
+        yield {
+            "candidate_id": cand.id,
+            "keys": [*cand_map.keys()],
+            "values": [*cand_map.values()],
+        }
 
 
 def get_cands_list_from_split(


### PR DESCRIPTION
This PR fix #328.

The root cause of #328 is that multiple processes (when PARALLEL >= 2) try to update the key tables (LabelKey and FeatureKey) at the same time with almost the same content.
This patch creates a method `UDFRunner.after_apply`, which will be executed by a single process.