### PR TITLE
Remove redundant split argument from LabelerUDF/FeaturizerUDF.apply

### DIFF
--- a/src/fonduer/features/featurizer.py
+++ b/src/fonduer/features/featurizer.py
@@ -25,7 +25,7 @@ from fonduer.utils.utils_udf import (
     batch_upsert_records,
     drop_all_keys,
     drop_keys,
-    get_cands_list_from_split,
+    get_cands_list_from_doc,
     get_docs_from_split,
     get_mapping,
     get_sparse_matrix,
@@ -336,7 +336,7 @@ class FeaturizerUDF(UDF):
         super().__init__(**kwargs)
 
     def apply(  # type: ignore
-        self, doc: Document, split: int, train: bool, **kwargs: Any
+        self, doc: Document, train: bool, **kwargs: Any
     ) -> Iterator[Any]:
         """Extract candidates from the given Context.
 
@@ -347,9 +347,7 @@ class FeaturizerUDF(UDF):
         logger.debug(f"Document: {doc}")
 
         # Get all the candidates in this doc that will be featurized
-        cands_list = get_cands_list_from_split(
-            self.session, self.candidate_classes, doc, split
-        )
+        cands_list = get_cands_list_from_doc(self.session, self.candidate_classes, doc)
 
         # Make a flat list of all candidates from the list of list of
         # candidates. This helps reduce the number of queries needed to update.

--- a/src/fonduer/features/featurizer.py
+++ b/src/fonduer/features/featurizer.py
@@ -341,7 +341,6 @@ class FeaturizerUDF(UDF):
         """Extract candidates from the given Context.
 
         :param doc: A document to process.
-        :param split: Which split to use.
         :param train: Whether or not to insert new FeatureKeys.
         """
         logger.debug(f"Document: {doc}")

--- a/src/fonduer/supervision/labeler.py
+++ b/src/fonduer/supervision/labeler.py
@@ -403,11 +403,7 @@ class LabelerUDF(UDF):
                 )
 
     def apply(  # type: ignore
-        self,
-        doc: Document,
-        train: bool,
-        lfs: List[List[Callable]],
-        **kwargs: Any,
+        self, doc: Document, train: bool, lfs: List[List[Callable]], **kwargs: Any
     ):
         """Extract candidates from the given Context.
 

--- a/src/fonduer/supervision/labeler.py
+++ b/src/fonduer/supervision/labeler.py
@@ -26,7 +26,7 @@ from fonduer.utils.utils_udf import (
     batch_upsert_records,
     drop_all_keys,
     drop_keys,
-    get_cands_list_from_split,
+    get_cands_list_from_doc,
     get_docs_from_split,
     get_mapping,
     get_sparse_matrix,
@@ -405,7 +405,6 @@ class LabelerUDF(UDF):
     def apply(  # type: ignore
         self,
         doc: Document,
-        split: int,
         train: bool,
         lfs: List[List[Callable]],
         **kwargs: Any,
@@ -413,7 +412,6 @@ class LabelerUDF(UDF):
         """Extract candidates from the given Context.
 
         :param doc: A document to process.
-        :param split: Which split to use.
         :param train: Whether or not to insert new LabelKeys.
         :param lfs: The list of functions to use to generate labels.
         """
@@ -425,9 +423,7 @@ class LabelerUDF(UDF):
         self.lfs = lfs
 
         # Get all the candidates in this doc that will be labeled
-        cands_list = get_cands_list_from_split(
-            self.session, self.candidate_classes, doc, split
-        )
+        cands_list = get_cands_list_from_doc(self.session, self.candidate_classes, doc)
 
         for cands in cands_list:
             records = list(get_mapping(self.session, Label, cands, self._f_gen))

--- a/src/fonduer/utils/utils_udf.py
+++ b/src/fonduer/utils/utils_udf.py
@@ -10,7 +10,6 @@ from typing import (
     Set,
     Tuple,
     Type,
-    Union,
 )
 
 from scipy.sparse import csr_matrix
@@ -220,31 +219,17 @@ def get_mapping(
         }
 
 
-def get_cands_list_from_split(
-    session: Session,
-    candidate_classes: Iterable[Type[Candidate]],
-    doc: Document,
-    split: Union[int, str],
+def get_cands_list_from_doc(
+    session: Session, candidate_classes: Iterable[Type[Candidate]], doc: Document
 ) -> List[List[Candidate]]:
     """Return the list of list of candidates from this document based on the split."""
     cands = []
-    if split == ALL_SPLITS:
-        # Get cands from all splits
-        for candidate_class in candidate_classes:
-            cands.append(
-                session.query(candidate_class)
-                .filter(candidate_class.document_id == doc.id)
-                .all()
-            )
-    else:
-        # Get cands from the specified split
-        for candidate_class in candidate_classes:
-            cands.append(
-                session.query(candidate_class)
-                .filter(candidate_class.document_id == doc.id)
-                .filter(candidate_class.split == split)
-                .all()
-            )
+    for candidate_class in candidate_classes:
+        cands.append(
+            session.query(candidate_class)
+            .filter(candidate_class.document_id == doc.id)
+            .all()
+        )
     return cands
 
 

--- a/src/fonduer/utils/utils_udf.py
+++ b/src/fonduer/utils/utils_udf.py
@@ -222,7 +222,7 @@ def get_mapping(
 def get_cands_list_from_doc(
     session: Session, candidate_classes: Iterable[Type[Candidate]], doc: Document
 ) -> List[List[Candidate]]:
-    """Return the list of list of candidates from this document based on the split."""
+    """Return the list of list of candidates from this document."""
     cands = []
     for candidate_class in candidate_classes:
         cands.append(


### PR DESCRIPTION
The `split` argument at LabelerUDF/FeaturizerUDF.apply is redundant because it is already resolved to a list of docs at Labeler/Featurizer.apply.
No need to be mentioned at CHANGELOG as it has no impact on APIs (LabelerUDF/FeaturizerUDF are not meant to be used by a user).