### PR TITLE
Labeler.apply with docs instead of split fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -101,6 +101,8 @@ Fixed
 * `@HiromuHota`_: Fix deadlock error during Labeler.apply and Featurizer.apply.
   (`#328 <https://github.com/HazyResearch/fonduer/issues/328>`_)
 * `@HiromuHota`_: Avoid networkx 2.4 so that snorkel-metal does not use the removed API.
+* `@HiromuHota`_: Fix the issue that Labeler.apply with docs instead of split fails.
+  (`#340 <https://github.com/HazyResearch/fonduer/pull/340>`_)
 
 0.7.0_ - 2019-06-12
 -------------------

--- a/src/fonduer/supervision/labeler.py
+++ b/src/fonduer/supervision/labeler.py
@@ -268,9 +268,14 @@ class Labeler(UDFRunner):
         # Clear Labels for the candidates in the split passed in.
         logger.info(f"Clearing Labels (split {split})")
 
-        sub_query = (
-            self.session.query(Candidate.id).filter(Candidate.split == split).subquery()
-        )
+        if split == ALL_SPLITS:
+            sub_query = self.session.query(Candidate.id).subquery()
+        else:
+            sub_query = (
+                self.session.query(Candidate.id)
+                .filter(Candidate.split == split)
+                .subquery()
+            )
         query = self.session.query(Label).filter(Label.candidate_id.in_(sub_query))
         query.delete(synchronize_session="fetch")
 

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -341,7 +341,10 @@ def test_e2e(caplog):
         labeler.apply(split=0, lfs=stg_temp_lfs, train=True, parallelism=PARALLEL)
 
     labeler.apply(
-        split=0, lfs=[stg_temp_lfs, ce_v_max_lfs], train=True, parallelism=PARALLEL
+        docs=train_docs,
+        lfs=[stg_temp_lfs, ce_v_max_lfs],
+        train=True,
+        parallelism=PARALLEL,
     )
     assert session.query(Label).count() == 6478
     assert session.query(LabelKey).count() == 9


### PR DESCRIPTION
The first commit demonstrates that labeler.apply with docs instead of split fails.
Later commits will fix this issue.