### PR TITLE
Depend on psycopg2 instead of psycopg2-binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,8 @@ before_install:
     pg_ctl -D /usr/local/var/postgres start; sleep 5
     createuser -s postgres
     # poppler-utils is already installed
+    # https://github.com/brianmario/mysql2/issues/795
+    export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/openssl@1.1/lib/
   fi
 - pdfinfo -v
 - psql --version

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -98,6 +98,7 @@ Changed
 * `@HiromuHota`_: Use the official name "beautifulsoup4" instead of an alias "bs4".
   (`#306 <https://github.com/HazyResearch/fonduer/issues/306>`_)
 * `@HiromuHota`_: Pin PyTorch on 1.1.0 to align with Snorkel of 0.9.X.
+* `@HiromuHota`_: Depend on psycopg2 instead of psycopg2-binary as the latter is not recommended for production.
 
 Removed
 ^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "snorkel-metal>=0.4.1, <0.5.0",
         "networkx>=2.2, <2.4",
         "spacy>=2.1.3, <2.2.0",
-        "sqlalchemy[postgresql_psycopg2binary]>=1.2.12, <2.0.0",
+        "sqlalchemy[postgresql]>=1.2.12, <2.0.0",
         "tensorboardX>=1.6, <2.0",
         "torch>=1.1.0,<1.2.0",
         "tqdm>=4.26.0, <5.0.0",


### PR DESCRIPTION
As stated in https://pypi.org/project/psycopg2/ that
> The binary package is a practical choice for development and testing but in production it is advised to use the package built from sources.

also in http://initd.org/psycopg/docs/install.html#binary-packages that
> If you are the maintainer of a publish package depending on psycopg2 you shouldn’t use ‘psycopg2-binary’ as a module dependency. For production use you are advised to use the source distribution.

Fonduer should depend on psycopg2 and build it from source.