### PR TITLE
Use 127.0.0.1 instead of localhost not to call getaddrinfo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,6 @@ install:
 - python -m spacy download en
 
 before_script:
-- createdb parser_test -U postgres
 - createdb e2e_test -U postgres
 - createdb visualizer_test -U postgres
 - createdb inc_test -U postgres

--- a/docs/dev/tests.rst
+++ b/docs/dev/tests.rst
@@ -8,7 +8,6 @@ locally.
 In order to run the tests, you will need to create the local databases used
 by the tests::
 
-    $ createdb parser_test
     $ createdb e2e_test
     $ createdb cand_test
     $ createdb feature_test

--- a/tests/candidates/test_candidates.py
+++ b/tests/candidates/test_candidates.py
@@ -46,6 +46,7 @@ from tests.shared.hardware_throttlers import temp_throttler, volt_throttler
 logger = logging.getLogger(__name__)
 ATTRIBUTE = "stg_temp_max"
 DB = "cand_test"
+# Use 127.0.0.1 instead of localhost (#351)
 CONN_STRING = f"postgresql://127.0.0.1:5432/{DB}"
 
 

--- a/tests/candidates/test_candidates.py
+++ b/tests/candidates/test_candidates.py
@@ -45,7 +45,7 @@ from tests.shared.hardware_throttlers import temp_throttler, volt_throttler
 
 logger = logging.getLogger(__name__)
 ATTRIBUTE = "stg_temp_max"
-DB = "cand_test"
+CONN_STRING = "postgresql://127.0.0.1:5432/cand_test"
 
 
 def test_ngram_split():
@@ -199,7 +199,7 @@ def test_cand_gen_cascading_delete():
         PARALLEL = 2  # Travis only gives 2 cores
 
     max_docs = 1
-    session = Meta.init("postgresql://localhost:5432/" + DB).Session()
+    session = Meta.init(CONN_STRING).Session()
 
     docs_path = "tests/data/html/"
     pdf_path = "tests/data/pdf/"
@@ -279,7 +279,7 @@ def test_cand_gen():
         return True
 
     max_docs = 1
-    session = Meta.init("postgresql://localhost:5432/" + DB).Session()
+    session = Meta.init(CONN_STRING).Session()
 
     docs_path = "tests/data/html/"
     pdf_path = "tests/data/pdf/"
@@ -424,7 +424,7 @@ def test_ngrams():
     PARALLEL = 4
 
     max_docs = 1
-    session = Meta.init("postgresql://localhost:5432/" + DB).Session()
+    session = Meta.init(CONN_STRING).Session()
 
     docs_path = "tests/data/pure_html/lincoln_short.html"
 
@@ -467,7 +467,7 @@ def test_row_col_ngram_extraction():
     """Test whether row/column ngrams list is empty, if mention is not in a table."""
     PARALLEL = 1
     max_docs = 1
-    session = Meta.init("postgresql://localhost:5432/" + DB).Session()
+    session = Meta.init(CONN_STRING).Session()
     docs_path = "tests/data/pure_html/lincoln_short.html"
 
     # Parsing
@@ -509,7 +509,7 @@ def test_mention_longest_match():
     PARALLEL = 1
 
     max_docs = 1
-    session = Meta.init("postgresql://localhost:5432/" + DB).Session()
+    session = Meta.init(CONN_STRING).Session()
 
     docs_path = "tests/data/pure_html/lincoln_short.html"
 
@@ -573,7 +573,7 @@ def test_multimodal_cand():
     PARALLEL = 4
 
     max_docs = 1
-    session = Meta.init("postgresql://localhost:5432/" + DB).Session()
+    session = Meta.init(CONN_STRING).Session()
 
     docs_path = "tests/data/pure_html/radiology.html"
 
@@ -628,10 +628,9 @@ def test_subclass_before_meta_init():
     """Test if it is possible to create a mention (candidate) subclass even before Meta
     is initialized.
     """
-    conn_string = "postgresql://localhost:5432/" + DB
     Part = mention_subclass("Part")
     logger.info(f"Create a mention subclass '{Part.__tablename__}'")
-    Meta.init(conn_string).Session()
+    Meta.init(CONN_STRING).Session()
     Temp = mention_subclass("Temp")
     logger.info(f"Create a mention subclass '{Temp.__tablename__}'")
 

--- a/tests/candidates/test_candidates.py
+++ b/tests/candidates/test_candidates.py
@@ -45,7 +45,8 @@ from tests.shared.hardware_throttlers import temp_throttler, volt_throttler
 
 logger = logging.getLogger(__name__)
 ATTRIBUTE = "stg_temp_max"
-CONN_STRING = "postgresql://127.0.0.1:5432/cand_test"
+DB = "cand_test"
+CONN_STRING = f"postgresql://127.0.0.1:5432/{DB}"
 
 
 def test_ngram_split():

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -56,7 +56,8 @@ from tests.shared.hardware_utils import entity_level_f1, gold
 
 logger = logging.getLogger(__name__)
 ATTRIBUTE = "stg_temp_max"
-CONN_STRING = "postgresql://127.0.0.1:5432/e2e_test"
+DB = "e2e_test"
+CONN_STRING = f"postgresql://127.0.0.1:5432/{DB}"
 
 
 @pytest.mark.skipif("CI" not in os.environ, reason="Only run e2e on Travis")

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -57,6 +57,7 @@ from tests.shared.hardware_utils import entity_level_f1, gold
 logger = logging.getLogger(__name__)
 ATTRIBUTE = "stg_temp_max"
 DB = "e2e_test"
+# Use 127.0.0.1 instead of localhost (#351)
 CONN_STRING = f"postgresql://127.0.0.1:5432/{DB}"
 
 

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -56,7 +56,7 @@ from tests.shared.hardware_utils import entity_level_f1, gold
 
 logger = logging.getLogger(__name__)
 ATTRIBUTE = "stg_temp_max"
-DB = "e2e_test"
+CONN_STRING = "postgresql://127.0.0.1:5432/e2e_test"
 
 
 @pytest.mark.skipif("CI" not in os.environ, reason="Only run e2e on Travis")
@@ -72,7 +72,7 @@ def test_e2e():
         level=logging.INFO,
     )
 
-    session = fonduer.Meta.init("postgresql://localhost:5432/" + DB).Session()
+    session = fonduer.Meta.init(CONN_STRING).Session()
 
     docs_path = "tests/data/html/"
     pdf_path = "tests/data/pdf/"

--- a/tests/e2e/test_incremental.py
+++ b/tests/e2e/test_incremental.py
@@ -28,6 +28,7 @@ from tests.shared.hardware_throttlers import temp_throttler
 logger = logging.getLogger(__name__)
 ATTRIBUTE = "stg_temp_max"
 DB = "inc_test"
+# Use 127.0.0.1 instead of localhost (#351)
 CONN_STRING = f"postgresql://127.0.0.1:5432/{DB}"
 
 

--- a/tests/e2e/test_incremental.py
+++ b/tests/e2e/test_incremental.py
@@ -27,7 +27,8 @@ from tests.shared.hardware_throttlers import temp_throttler
 
 logger = logging.getLogger(__name__)
 ATTRIBUTE = "stg_temp_max"
-CONN_STRING = "postgresql://127.0.0.1:5432/inc_test"
+DB = "inc_test"
+CONN_STRING = f"postgresql://127.0.0.1:5432/{DB}"
 
 
 @pytest.mark.skipif("CI" not in os.environ, reason="Only run incremental on Travis")

--- a/tests/e2e/test_incremental.py
+++ b/tests/e2e/test_incremental.py
@@ -27,7 +27,7 @@ from tests.shared.hardware_throttlers import temp_throttler
 
 logger = logging.getLogger(__name__)
 ATTRIBUTE = "stg_temp_max"
-DB = "inc_test"
+CONN_STRING = "postgresql://127.0.0.1:5432/inc_test"
 
 
 @pytest.mark.skipif("CI" not in os.environ, reason="Only run incremental on Travis")
@@ -37,7 +37,7 @@ def test_incremental():
 
     max_docs = 1
 
-    session = Meta.init("postgresql://localhost:5432/" + DB).Session()
+    session = Meta.init(CONN_STRING).Session()
 
     docs_path = "tests/data/html/dtc114w.html"
     pdf_path = "tests/data/pdf/dtc114w.pdf"

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -11,7 +11,8 @@ from fonduer.parser.preprocessors import HTMLDocPreprocessor
 from tests.shared.hardware_matchers import part_matcher, temp_matcher
 
 logger = logging.getLogger(__name__)
-CONN_STRING = "postgresql://127.0.0.1:5432/feature_test"
+DB = "feature_test"
+CONN_STRING = f"postgresql://127.0.0.1:5432/{DB}"
 
 
 def test_feature_extraction():

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -12,6 +12,7 @@ from tests.shared.hardware_matchers import part_matcher, temp_matcher
 
 logger = logging.getLogger(__name__)
 DB = "feature_test"
+# Use 127.0.0.1 instead of localhost (#351)
 CONN_STRING = f"postgresql://127.0.0.1:5432/{DB}"
 
 

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -11,7 +11,7 @@ from fonduer.parser.preprocessors import HTMLDocPreprocessor
 from tests.shared.hardware_matchers import part_matcher, temp_matcher
 
 logger = logging.getLogger(__name__)
-DB = "feature_test"
+CONN_STRING = "postgresql://127.0.0.1:5432/feature_test"
 
 
 def test_feature_extraction():
@@ -19,7 +19,7 @@ def test_feature_extraction():
     PARALLEL = 1
 
     max_docs = 1
-    session = Meta.init("postgresql://localhost:5432/" + DB).Session()
+    session = Meta.init(CONN_STRING).Session()
 
     docs_path = "tests/data/html/"
     pdf_path = "tests/data/pdf/"

--- a/tests/utils/test_visualizer.py
+++ b/tests/utils/test_visualizer.py
@@ -12,7 +12,7 @@ from fonduer.parser import Parser
 from fonduer.parser.models import Document
 from fonduer.parser.preprocessors import HTMLDocPreprocessor
 
-ATTRIBUTE = "visualizer_test"
+CONN_STRING = "postgresql://127.0.0.1:5432/visualizer_test"
 
 
 def test_visualizer():
@@ -20,7 +20,7 @@ def test_visualizer():
 
     """Unit test of visualizer using the md document.
     """
-    session = Meta.init("postgresql://localhost:5432/" + ATTRIBUTE).Session()
+    session = Meta.init(CONN_STRING).Session()
 
     PARALLEL = 1
     max_docs = 1

--- a/tests/utils/test_visualizer.py
+++ b/tests/utils/test_visualizer.py
@@ -13,6 +13,7 @@ from fonduer.parser.models import Document
 from fonduer.parser.preprocessors import HTMLDocPreprocessor
 
 DB = "visualizer_test"
+# Use 127.0.0.1 instead of localhost (#351)
 CONN_STRING = f"postgresql://127.0.0.1:5432/{DB}"
 
 

--- a/tests/utils/test_visualizer.py
+++ b/tests/utils/test_visualizer.py
@@ -12,7 +12,8 @@ from fonduer.parser import Parser
 from fonduer.parser.models import Document
 from fonduer.parser.preprocessors import HTMLDocPreprocessor
 
-CONN_STRING = "postgresql://127.0.0.1:5432/visualizer_test"
+DB = "visualizer_test"
+CONN_STRING = f"postgresql://127.0.0.1:5432/{DB}"
 
 
 def test_visualizer():


### PR DESCRIPTION
Reported at https://github.com/psycopg/psycopg2/issues/478 that
> it seems calling getaddrinfo repeatedly with 'localhost' is a no-no on osx.

The root cause has reportedly fixed at https://bugs.python.org/issue17269, but seems this issue still exists because
- The issue only happens on OSX
- The issue does not happen if localhost is replaced with 127.0.0.1


It is hard to reproduce the issue as it is the case for any race-condition issue.
Fortunately, tests for https://github.com/HazyResearch/fonduer/pull/347 on travis OSX were able to reproduce the error every time it ran.
And this PR stopped the error.