### PR TITLE
Merge _apply_mt and _apply_st for maintainability

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+concurrency = multiprocessing

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
 concurrency = multiprocessing
+source = fonduer

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ before_script:
 - cd tests && ./download_data.sh && cd ..
 
 script:
-- travis_wait 50 coverage run --source=fonduer -m pytest tests
+- travis_wait 50 coverage run -m pytest tests
 
 after_success:
 - coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,7 @@ script:
 - travis_wait 50 coverage run --source=fonduer -m pytest tests
 
 after_success:
+- coverage combine
 - coveralls
 
 deploy:

--- a/src/fonduer/utils/udf.py
+++ b/src/fonduer/utils/udf.py
@@ -77,7 +77,7 @@ class UDFRunner(object):
 
         # Use the parallelism of the class if none is provided to apply
         parallelism = parallelism if parallelism else self.parallelism
-        self._apply_mt(doc_loader, parallelism, clear=clear, **kwargs)
+        self._apply(doc_loader, parallelism, clear=clear, **kwargs)
 
         # Close progress bar
         if self.pb is not None:
@@ -95,7 +95,7 @@ class UDFRunner(object):
         """This method is executed by a single process after apply."""
         pass
 
-    def _apply_mt(
+    def _apply(
         self, doc_loader: Collection[Document], parallelism: int, **kwargs: Any
     ) -> None:
         """Run the UDF multi-threaded using python multiprocessing"""

--- a/src/fonduer/utils/udf.py
+++ b/src/fonduer/utils/udf.py
@@ -77,10 +77,7 @@ class UDFRunner(object):
 
         # Use the parallelism of the class if none is provided to apply
         parallelism = parallelism if parallelism else self.parallelism
-        if parallelism < 2:
-            self._apply_st(doc_loader, clear=clear, **kwargs)
-        else:
-            self._apply_mt(doc_loader, parallelism, clear=clear, **kwargs)
+        self._apply_mt(doc_loader, parallelism, clear=clear, **kwargs)
 
         # Close progress bar
         if self.pb is not None:
@@ -97,23 +94,6 @@ class UDFRunner(object):
     def _after_apply(self, **kwargs: Any) -> None:
         """This method is executed by a single process after apply."""
         pass
-
-    def _apply_st(self, doc_loader: Collection[Document], **kwargs: Any) -> None:
-        """Run the UDF single-threaded, optionally with progress bar"""
-        udf = self.udf_class(**self.udf_init_kwargs)
-        Session = new_sessionmaker()
-        udf.session = Session()
-
-        # Run single-thread
-        for doc in doc_loader:
-            if self.pb is not None:
-                self.pb.update(1)
-
-            udf.session.add_all(y for y in udf.apply(doc, **kwargs))
-
-        # Commit and close session
-        udf.session.commit()
-        udf.session.close()
 
     def _apply_mt(
         self, doc_loader: Collection[Document], parallelism: int, **kwargs: Any


### PR DESCRIPTION
This PR merges `_apply_mt` and `_apply_st` for better maintainability.

Even when parallelism==1, this PR will spawn another process.
This doesn't sound computationally efficient, but should be fine because parallelism==1 means that the task itself is small.

This is a rework of #347.