### PR TITLE
Conform to black==19.10b0

### DIFF
--- a/src/fonduer/features/feature_libs/structural_features.py
+++ b/src/fonduer/features/feature_libs/structural_features.py
@@ -23,7 +23,7 @@ binary_strlib_feats: Dict[str, Set[Tuple[str, int]]] = {}
 
 
 def extract_structural_features(
-    candidates: List[Candidate]
+    candidates: List[Candidate],
 ) -> Iterator[Tuple[int, str, int]]:
     """Extract structural features.
 

--- a/src/fonduer/features/feature_libs/tabular_features.py
+++ b/src/fonduer/features/feature_libs/tabular_features.py
@@ -21,7 +21,7 @@ settings = get_config()
 
 
 def extract_tabular_features(
-    candidates: List[Candidate]
+    candidates: List[Candidate],
 ) -> Iterator[Tuple[int, str, int]]:
     """Extract tabular features.
 

--- a/src/fonduer/features/feature_libs/textual_features.py
+++ b/src/fonduer/features/feature_libs/textual_features.py
@@ -32,7 +32,7 @@ settings = get_config()
 
 
 def extract_textual_features(
-    candidates: List[Candidate]
+    candidates: List[Candidate],
 ) -> Iterator[Tuple[int, str, int]]:
     """Extract textual features.
 

--- a/src/fonduer/features/feature_libs/visual_features.py
+++ b/src/fonduer/features/feature_libs/visual_features.py
@@ -20,7 +20,7 @@ binary_vizlib_feats: Dict[str, Set] = {}
 
 
 def extract_visual_features(
-    candidates: List[Candidate]
+    candidates: List[Candidate],
 ) -> Iterator[Tuple[int, str, int]]:
     """Extract visual features.
 


### PR DESCRIPTION
black==19.10b0 has been released today (10/28) and the current codes do not conform to it.
This PR makes the codes conform to black>=18.9b0 (18.9b0, 19.3b0, 19.10b0).