### PR TITLE
Deprecation warning for Classifier and its subclass disc_models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -100,6 +100,10 @@ Changed
 * `@HiromuHota`_: Pin PyTorch on 1.1.0 to align with Snorkel of 0.9.X.
 * `@HiromuHota`_: Depend on psycopg2 instead of psycopg2-binary as the latter is not recommended for production.
 
+Deprecated
+^^^^^^^^^^
+* `@HiromuHota`_: Classifier and its subclass disc_models are deprecated, and in v0.8.0 they will be removed.
+
 Removed
 ^^^^^^^
 

--- a/src/fonduer/learning/classifier.py
+++ b/src/fonduer/learning/classifier.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import warnings
 from datetime import datetime
 from shutil import copyfile
 from time import time
@@ -17,6 +18,12 @@ from fonduer import Meta
 from fonduer.learning.disc_models.modules.loss import SoftCrossEntropyLoss
 from fonduer.learning.utils import MultiModalDataset, save_marginals
 from fonduer.utils.logging import TensorBoardLogger
+
+warnings.warn(
+    "Classifier and its subclass disc_models are deprecated, \
+        and in v0.8.0 they will be removed. Use Emmental instead.",
+    DeprecationWarning,
+)
 
 
 class Classifier(nn.Module):


### PR DESCRIPTION
#329 will remove Classifier and its subclass disc_models.
This PR adds a deprecation warning for this, which is triggered by importing any of these disc_models.