### PR TITLE
Add required packages to build psycopg2 for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     poppler-utils \
     postgresql-client \
     libmagickwand-dev \
+    libpq-dev \
+    build-essential \
  && rm /etc/ImageMagick-6/policy.xml \
  && rm -rf /var/lib/{apt,dpkg,cache,log}/
 


### PR DESCRIPTION
Because of #349, psycopg2 will be built from source.
This means Dockefile has to install build-essential like gcc.