### PR TITLE
To support ImageMagick7, expand the version range of Wand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,7 @@ before_install:
     brew install swig mecab mecab-unidic
     sed -i -e "s/ipadic/unidic/" /usr/local/etc/mecabrc
     # Install ImageMagick library for Wand
-    brew install freetype imagemagick@6 ghostscript
-    # https://stackoverflow.com/a/41772062
-    ln -s `brew info imagemagick@6 | grep ^/usr | awk '{print $1}'`/lib/libMagickWand-6.Q16.dylib /usr/local/lib/libMagickWand.dylib
+    brew install freetype imagemagick ghostscript
     # Install PostgreSQL 10 (12 not compatible with Fonduer)
     # See https://github.com/HazyResearch/fonduer/issues/371
     brew uninstall --ignore-dependencies postgresql

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -122,6 +122,7 @@ Changed
   (`#358 <https://github.com/HazyResearch/fonduer/issues/358>`_)
 * `@HiromuHota`_: Use tqdm.notebook.tqdm instead of deprecated tqdm.tqdm_notebook.
   (`#360 <https://github.com/HazyResearch/fonduer/issues/360>`_)
+* `@HiromuHota`_: To support ImageMagick7, expand the version range of Wand.
 
 0.7.1_ - 2019-11-06
 -------------------

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -17,7 +17,7 @@ For OS X using homebrew_::
     $ brew install postgresql@10
     $ brew install libpng freetype pkg-config
     $ brew install libomp #https://github.com/pytorch/pytorch/issues/20030
-    $ brew install imagemagick@6
+    $ brew install imagemagick
 
 On Debian-based distros::
 
@@ -39,7 +39,7 @@ On Debian-based distros::
     to avoid `a known bug <https://bugs.freedesktop.org/show_bug.cgi?id=97399>`_.
 
 .. note::
-    Fonduer depends on Wand (>=0.4.4, <0.5.0), which does not support ImageMagick7.
+    Use Wand (>=0.5.0) with ImageMagick7 as Wand (<0.5.0) does not support ImageMagick7.
 
 Installing the Fonduer Package
 ------------------------------

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "torch>=1.1.0,<1.2.0",
         "tqdm>=4.36.0, <5.0.0",
         "treedlib>=0.1.1, <0.2.0",
-        "wand>=0.4.4, <0.5.0",
+        "wand>=0.4.4, <0.6.0",
         "ipython",
     ],
     extras_require={


### PR DESCRIPTION
The default version of ImageMagick is different among OS.
- Mac (Homebrew): 7
- Ubuntu (Bionic 18.04): 6.9

Currently Fonduer depends on Wand (>=0.4.4, <0.5.0), which does not support ImageMagick7.
This is why we had to install ImageMagick6 on Mac.

Wand 0.5.X supports both ImageMagick6 and 7.
As far as [CHANGELOG](http://docs.wand-py.org/en/0.5.8/changes.html#changelog-0-5) is concerned, 0.5.X did not introduce breaking changes.
Now is the time to expand the version range of Wand to include 0.5.X.