### PR TITLE
Make test_meta.py use only 'meta_test'

### DIFF
--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -23,8 +23,6 @@ def test_meta_connection_strings():
 
     Meta.init("postgresql://localhost:5432/" + DB).Session()
     assert Meta.DBNAME == DB
-    Meta.init("postgresql://localhost:5432/" + "cand_test").Session()
-    assert Meta.DBNAME == "cand_test"
 
 
 def test_subclass_before_meta_init():


### PR DESCRIPTION
This is the second part of the PR #368.