### PR TITLE
Use Python installed by default

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -97,6 +97,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies for macOS
       run: |
+        pip3 install virtualenv
+        virtualenv venv
+        source venv/bin/activate
+
         brew update
         brew install swig mecab mecab-unidic
         # Use unidic-mecab dictionary
@@ -135,14 +139,10 @@ jobs:
         pip3 --version
         mecab -D || true
         neofetch
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v2
     - name: Install Fonduer
       run: |
-        pip3 install -r requirements-dev.txt
-        pip3 install .[spacy_ja]
-        pip3 install .[spacy_zh]
-        pip3 install -q coveralls
+        make dev_extra
+        pip3 install coveralls
     - name: Run preliminary checks
       run: |
         make check

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -93,13 +93,8 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        python-version: [3.6, 3.7]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Install dependencies for macOS
       run: |
         brew update

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -95,10 +95,6 @@ jobs:
         os: [macos-latest]
     steps:
     - uses: actions/checkout@v2
-    - name: Alias for pip and python for macOS
-      run: |
-        alias pip=pip3
-        alias python=python3
     - name: Install dependencies for macOS
       run: |
         brew update

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -135,6 +135,8 @@ jobs:
         pip3 --version
         mecab -D || true
         neofetch
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v2
     - name: Install Fonduer
       run: |
         make dev_extra

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -99,7 +99,9 @@ jobs:
       run: |
         pip3 install virtualenv
         virtualenv venv
-        source venv/bin/activate
+        VIRTUAL_ENV=`pwd`/venv
+        echo "::set-env name=VIRTUAL_ENV::$VIRTUAL_ENV"
+        echo "::add-path::$VIRTUAL_ENV/bin"
 
         brew update
         brew install swig mecab mecab-unidic
@@ -133,30 +135,26 @@ jobs:
         cd tests && ./download_data.sh && cd ..
     - name: Print Version Info
       run: |
-        source venv/bin/activate
         pdfinfo -v
         psql --version
-        python3 --version
-        pip3 --version
+        python --version
+        pip --version
         mecab -D || true
         neofetch
     - name: Install Fonduer
       run: |
-        source venv/bin/activate
         make dev_extra
-        pip3 install coveralls
+        pip install coveralls
     - name: Run preliminary checks
       run: |
-        source venv/bin/activate
         make check
         make docs
       env:
         PGPASSWORD: postgres
     - name: Test with pytest
       run: |
-        source venv/bin/activate
-        python3 -m spacy download en
-        python3 -m pytest tests
+        python -m spacy download en
+        python -m pytest tests
       env:
         CI: true
         PGPASSWORD: postgres

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -139,7 +139,9 @@ jobs:
       uses: mxschmitt/action-tmate@v2
     - name: Install Fonduer
       run: |
-        make dev_extra
+        pip3 install -r requirements-dev.txt
+        pip3 install .[spacy_ja]
+        pip3 install .[spacy_zh]
         pip3 install -q coveralls
     - name: Run preliminary checks
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -95,6 +95,12 @@ jobs:
         os: [macos-latest]
     steps:
     - uses: actions/checkout@v2
+# actions/setup-python@v1 cannot be used on macos because
+# "Can't connect to HTTPS URL because the SSL module is not available."
+# error happens when trying to pip install
+# This is probably because brew install openssl@1.1 as imagemagick dependency
+# and breaks a link Python installed actions/setup-python@v1 and openssl.
+# Instead Python installed by default is used.
     - name: Install dependencies for macOS
       run: |
         pip3 install virtualenv

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -131,14 +131,14 @@ jobs:
       run: |
         pdfinfo -v
         psql --version
-        python --version
-        pip --version
+        python3 --version
+        pip3 --version
         mecab -D || true
         neofetch
     - name: Install Fonduer
       run: |
         make dev_extra
-        pip install -q coveralls
+        pip3 install -q coveralls
     - name: Run preliminary checks
       run: |
         make check
@@ -147,8 +147,8 @@ jobs:
         PGPASSWORD: postgres
     - name: Test with pytest
       run: |
-        python -m spacy download en
-        python -m pytest tests
+        python3 -m spacy download en
+        python3 -m pytest tests
       env:
         CI: true
         PGPASSWORD: postgres

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -95,12 +95,7 @@ jobs:
         os: [macos-latest]
     steps:
     - uses: actions/checkout@v2
-# actions/setup-python@v1 cannot be used on macos because
-# "Can't connect to HTTPS URL because the SSL module is not available."
-# error happens when trying to pip install
-# This is probably because brew install openssl@1.1 as imagemagick dependency
-# and breaks a link Python installed actions/setup-python@v1 and openssl.
-# Instead Python installed by default is used.
+    # actions/setup-python@v1 cannot be used on macos (see #386)
     - name: Install dependencies for macOS
       run: |
         pip3 install virtualenv

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,8 +24,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Update Python ${{ matrix.python-version }} tools
-      run: python -m pip install --upgrade pip setuptools wheel
     - name: Install dependencies for Ubuntu
       run: |
         sudo apt-get install neofetch
@@ -102,8 +100,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Update Python ${{ matrix.python-version }} tools
-      run: python -m pip install --upgrade pip setuptools wheel
     - name: Install dependencies for macOS
       run: |
         brew update
@@ -146,9 +142,8 @@ jobs:
         neofetch
     - name: Install Fonduer
       run: |
-        python -m pip install -r requirements-dev.txt
-        python -m pip install -e .[spacy_ja]
-        python -m pip install -e .[spacy_zh]
+        make dev_extra
+        pip install -q coveralls
     - name: Run preliminary checks
       run: |
         make check

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -133,6 +133,7 @@ jobs:
         cd tests && ./download_data.sh && cd ..
     - name: Print Version Info
       run: |
+        source venv/bin/activate
         pdfinfo -v
         psql --version
         python3 --version
@@ -141,16 +142,19 @@ jobs:
         neofetch
     - name: Install Fonduer
       run: |
+        source venv/bin/activate
         make dev_extra
         pip3 install coveralls
     - name: Run preliminary checks
       run: |
+        source venv/bin/activate
         make check
         make docs
       env:
         PGPASSWORD: postgres
     - name: Test with pytest
       run: |
+        source venv/bin/activate
         python3 -m spacy download en
         python3 -m pytest tests
       env:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -95,6 +95,10 @@ jobs:
         os: [macos-latest]
     steps:
     - uses: actions/checkout@v2
+    - name: Alias for pip and python for macOS
+      run: |
+        alias pip=pip3
+        alias python=python3
     - name: Install dependencies for macOS
       run: |
         brew update

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
 TESTDATA=tests/input
 
 dev:
-	pip3 install -r requirements-dev.txt
-	pip3 install -e .
+	pip install -r requirements-dev.txt
+	pip install -e .
 	pre-commit install
 
 dev_extra:
-	pip3 install -r requirements-dev.txt
-	pip3 install -e .[spacy_ja]
-	pip3 install -e .[spacy_zh]
+	pip install -r requirements-dev.txt
+	pip install -e .[spacy_ja]
+	pip install -e .[spacy_zh]
 	pre-commit install
 
 test: dev check docs
-	pip3 install -e .
+	pip install -e .
 	pytest tests
 
 check:
@@ -28,7 +28,7 @@ docs:
 	sphinx-build -W -b html docs/ _build/html
 
 clean:
-	pip3 uninstall -y fonduer
+	pip uninstall -y fonduer
 	rm -rf src/fonduer.egg-info
 	rm -rf _build/
 

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
 TESTDATA=tests/input
 
 dev:
-	pip install -r requirements-dev.txt
-	pip install -e .
+	pip3 install -r requirements-dev.txt
+	pip3 install -e .
 	pre-commit install
 
 dev_extra:
-	pip install -r requirements-dev.txt
-	pip install -e .[spacy_ja]
-	pip install -e .[spacy_zh]
+	pip3 install -r requirements-dev.txt
+	pip3 install -e .[spacy_ja]
+	pip3 install -e .[spacy_zh]
 	pre-commit install
 
 test: dev check docs
-	pip install -e .
+	pip3 install -e .
 	pytest tests
 
 check:
@@ -28,7 +28,7 @@ docs:
 	sphinx-build -W -b html docs/ _build/html
 
 clean:
-	pip uninstall -y fonduer
+	pip3 uninstall -y fonduer
 	rm -rf src/fonduer.egg-info
 	rm -rf _build/
 


### PR DESCRIPTION
On macOS, Python installed by default (3.7) is used.
actions/setup-python@v1 cannot be used on macos because "Can't connect to HTTPS URL because the SSL module is not available." error happens when trying to pip install.
Not confirmed, but this is probably because brew install openssl@1.1 as imagemagick dependency and breaks a link Python installed actions/setup-python@v1 and openssl.