### PR TITLE
switch 0-index

### DIFF
--- a/src/fonduer/learning/dataset.py
+++ b/src/fonduer/learning/dataset.py
@@ -136,7 +136,7 @@ class FonduerDataset(EmmentalDataset):
             self.Y_dict.update(
                 {
                     "labels": torch.from_numpy(
-                        np.random.randint(self.labels, size=len(self.candidates)) + 1
+                        np.random.randint(self.labels, size=len(self.candidates))
                     )
                 }
             )

--- a/src/fonduer/learning/task.py
+++ b/src/fonduer/learning/task.py
@@ -31,7 +31,7 @@ def loss(
         label = intermediate_output_dict[module_name][0].new_zeros(
             intermediate_output_dict[module_name][0].size()
         )
-        label.scatter_(1, (Y - 1).view(Y.size()[0], 1), 1.0)
+        label.scatter_(1, Y.view(Y.size()[0], 1), 1.0)
     else:
         label = Y
 


### PR DESCRIPTION
Previously we use 1-index since it has better system performance in labeling with most of the labels are ABSTAIN. While 1-index is not user friendly and 0-index is commonly used in machine learning. So we propose to switch back to 0-index in both Emmental and Fonduer.

