### PR TITLE
Update docs about postgresql version requirement

### DIFF
--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -29,7 +29,7 @@ On Debian-based distros::
     $ sudo apt install libmagickwand-dev
 
 .. note::
-    Fonduer is compatible with PostgreSQL version 9.6, 10, and 11 (12 is not compatible as of v0.7.1).
+    Fonduer requires PostgreSQL version 9.6 or higher.
 
 .. note::
     Fonduer requires ``poppler-utils`` to be version 0.36.0 or later.


### PR DESCRIPTION
Unit tests have been recently executed with PostgreSQL 12 without any error related to it.
Accordingly, #371 has been closed.
It'd be safe to lift the restriction, or is it too early?