### PR TITLE
refactor(supervision/labeler): raise error if gold contains ABSTAIN

### DIFF
--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -337,6 +337,10 @@ def test_e2e():
 
     labeler = Labeler(session, [PartTemp, PartVolt])
 
+    # This should raise an error, since gold labels are not yet loaded.
+    with pytest.raises(ValueError):
+        _ = labeler.get_gold_labels(train_cands, annotator="gold")
+
     labeler.apply(
         docs=last_docs,
         lfs=[[gold], [gold]],


### PR DESCRIPTION
If a user calls get_gold_labels before loading gold labels, they will
get a label matrix with all values being -1 (ABSTAIN)

    L_gold_train = labeler.get_gold_labels(train_cands, annotator='gold')
    print(L_gold_train[0].reshape(-1))
    [-1. -1. -1. ... -1. -1. -1.]

Without any indicator that that is incorrect, if they do an LFAnalysis
they will have 0 empirical accuracy.

To be more friendly to the user, we throw an error to indicate that this
is an error.

Closes #403.