### PR TITLE
Improve documentation of preprocessors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -164,3 +164,4 @@ texinfo_documents = [
 ]
 
 # -- Extension configuration -------------------------------------------------
+autoclass_content = "both"

--- a/src/fonduer/parser/preprocessors/csv_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/csv_doc_preprocessor.py
@@ -10,30 +10,14 @@ from fonduer.utils.utils_parser import build_node, column_constructor
 
 
 class CSVDocPreprocessor(DocPreprocessor):
-    """A generator which processes a CSV file or directory of CSV files into
-    a set of Document objects. It treats each line in the input file as a document.
-    It assumes that each column is one section and content in each column as one
-    paragraph as defalt. However, if the column is complex, an advanced parser
+    """A ``Document`` generator for CVS files.
+
+    It treats each line in the input file as a ``Document``.
+    It assumes that each column is one ``Section`` and content in each column as one
+    ``Paragraph`` by default. However, if the column is complex, an advanced parser
     may be used by specifying ``parser_rule`` parameter in a dict format where key
     is the column index and value is the specific parser, e,g., ``column_constructor``
     in ``fonduer.utils.utils_parser``.
-
-    :param path: filesystem path to file or directory to parse.
-    :type path: str
-    :param encoding: file encoding to use (e.g. "utf-8").
-    :type encoding: str
-    :param max_docs: the maximum number of ``Documents`` to produce.
-    :type max_docs: int
-    :param header: if the CSV file contain header or not, if yes, the header
-        will be used as Section name. default = False
-    :type header: bool
-    :param delim: delimiter to be used to separate columns when file has
-        more than one column. It is active only when ``column is not
-        None``. default=','
-    :type delim: int
-    :param parser_rule: The parser rule to be used to parse the specific column.
-        default = None
-    :rtype: A generator of ``Documents``.
     """
 
     def __init__(
@@ -45,6 +29,25 @@ class CSVDocPreprocessor(DocPreprocessor):
         delim: str = ",",
         parser_rule: Optional[Dict[int, Callable]] = None,
     ) -> None:
+        """
+        :param path: a path to file or directory, or a glob pattern. The basename
+            (as returned by ``os.path.basename``) should be unique among all files.
+        :type path: str
+        :param encoding: file encoding to use (e.g. "utf-8").
+        :type encoding: str
+        :param max_docs: the maximum number of ``Documents`` to produce.
+        :type max_docs: int
+        :param header: if the CSV file contain header or not, if yes, the header
+            will be used as Section name. default = False
+        :type header: bool
+        :param delim: delimiter to be used to separate columns when file has
+            more than one column. It is active only when ``column is not
+            None``. default=','
+        :type delim: int
+        :param parser_rule: The parser rule to be used to parse the specific column.
+            default = None
+        :rtype: A generator of ``Documents``.
+        """
         super().__init__(path, encoding, max_docs)
         self.header = header
         self.delim = delim

--- a/src/fonduer/parser/preprocessors/doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/doc_preprocessor.py
@@ -7,22 +7,22 @@ from fonduer.parser.models.document import Document
 
 
 class DocPreprocessor(object):
-    """
-    A generator which processes a file or directory of files into a set of
-    Document objects.
-
-    :param path: filesystem path to file or directory to parse.
-    :type path: str
-    :param encoding: file encoding to use (e.g. "utf-8").
-    :type encoding: str
-    :param max_docs: the maximum number of ``Documents`` to produce.
-    :type max_docs: int
-    :rtype: A generator of ``Documents``.
-    """
+    """An abstract class of a ``Document`` generator."""
 
     def __init__(
         self, path: str, encoding: str = "utf-8", max_docs: int = sys.maxsize
     ) -> None:
+        """
+        :param path: a path to file or directory, or a glob pattern. The basename
+            (as returned by ``os.path.basename``) should be unique among all files.
+        :type path: str
+        :param encoding: file encoding to use, defaults to "utf-8".
+        :type encoding: str, optional
+        :param max_docs: the maximum number of ``Documents`` to produce,
+            defaults to sys.maxsize.
+        :type max_docs: int, optional
+        :rtype: A generator of ``Documents``.
+        """
         self.path = path
         self.encoding = encoding
         self.max_docs = max_docs

--- a/src/fonduer/parser/preprocessors/doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/doc_preprocessor.py
@@ -9,7 +9,8 @@ from fonduer.parser.models.document import Document
 class DocPreprocessor(object):
     """An abstract class of a ``Document`` generator.
 
-    Unless otherwise stated by a subclass, it's assumed that there is one ``Document`` per file.
+    Unless otherwise stated by a subclass, it's assumed that there is one ``Document``
+    per file.
     """
 
     def __init__(

--- a/src/fonduer/parser/preprocessors/doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/doc_preprocessor.py
@@ -7,7 +7,10 @@ from fonduer.parser.models.document import Document
 
 
 class DocPreprocessor(object):
-    """An abstract class of a ``Document`` generator."""
+    """An abstract class of a ``Document`` generator.
+
+    Unless otherwise stated by a subclass, it's assumed that one ``Document`` per file.
+    """
 
     def __init__(
         self, path: str, encoding: str = "utf-8", max_docs: int = sys.maxsize

--- a/src/fonduer/parser/preprocessors/doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/doc_preprocessor.py
@@ -9,7 +9,7 @@ from fonduer.parser.models.document import Document
 class DocPreprocessor(object):
     """An abstract class of a ``Document`` generator.
 
-    Unless otherwise stated by a subclass, it's assumed that one ``Document`` per file.
+    Unless otherwise stated by a subclass, it's assumed that there is one ``Document`` per file.
     """
 
     def __init__(

--- a/src/fonduer/parser/preprocessors/html_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/html_doc_preprocessor.py
@@ -9,17 +9,7 @@ from fonduer.parser.preprocessors.doc_preprocessor import DocPreprocessor
 
 
 class HTMLDocPreprocessor(DocPreprocessor):
-    """A generator which processes an HTML file or directory of HTML files into
-    a set of Document objects.
-
-    :param encoding: file encoding to use (e.g. "utf-8").
-    :type encoding: str
-    :param path: filesystem path to file or directory to parse.
-    :type path: str
-    :param max_docs: the maximum number of ``Documents`` to produce.
-    :type max_docs: int
-    :rtype: A generator of ``Documents``.
-    """
+    """A ``Document`` generator for HTML files."""
 
     def _parse_file(self, fp: str, file_name: str) -> Iterator[Document]:
         with codecs.open(fp, encoding=self.encoding) as f:

--- a/src/fonduer/parser/preprocessors/text_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/text_doc_preprocessor.py
@@ -8,18 +8,9 @@ from fonduer.utils.utils_parser import build_node
 
 
 class TextDocPreprocessor(DocPreprocessor):
-    """A generator which processes a text file or directory of text files into
-    a set of Document objects.
+    """A ``Document`` generator for plain text files.
 
-    Assumes one document per file.
-
-    :param encoding: file encoding to use (e.g. "utf-8").
-    :type encoding: str
-    :param path: filesystem path to file or directory to parse.
-    :type path: str
-    :param max_docs: the maximum number of ``Documents`` to produce.
-    :type max_docs: int
-    :rtype: A generator of ``Documents``.
+    Assumes one ``Document`` per file.
     """
 
     def _parse_file(self, fp: str, file_name: str) -> Iterator[Document]:

--- a/src/fonduer/parser/preprocessors/text_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/text_doc_preprocessor.py
@@ -8,10 +8,7 @@ from fonduer.utils.utils_parser import build_node
 
 
 class TextDocPreprocessor(DocPreprocessor):
-    """A ``Document`` generator for plain text files.
-
-    Assumes one ``Document`` per file.
-    """
+    """A ``Document`` generator for plain text files."""
 
     def _parse_file(self, fp: str, file_name: str) -> Iterator[Document]:
         with codecs.open(fp, encoding=self.encoding) as f:

--- a/src/fonduer/parser/preprocessors/tsv_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/tsv_doc_preprocessor.py
@@ -10,6 +10,7 @@ from fonduer.utils.utils_parser import build_node
 class TSVDocPreprocessor(DocPreprocessor):
     """A ``Document`` generator for TSV files.
 
+    It treats each line in the input file as a ``Document``.
     The TSV file should have one (doc_name <tab> doc_text) per line.
     """
 

--- a/src/fonduer/parser/preprocessors/tsv_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/tsv_doc_preprocessor.py
@@ -8,20 +8,9 @@ from fonduer.utils.utils_parser import build_node
 
 
 class TSVDocPreprocessor(DocPreprocessor):
-    """A generator which processes a TSV file or directory of TSV files into
-    a set of Document objects.
+    """A ``Document`` generator for TSV files.
 
     The TSV file should have one (doc_name <tab> doc_text) per line.
-
-    :param path: filesystem path to file or directory to parse.
-    :type path: str
-    :param encoding: file encoding to use (e.g. "utf-8").
-    :type encoding: str
-    :param max_docs: the maximum number of ``Documents`` to produce.
-    :type max_docs: int
-    :param header: if the TSV file contain header or not. default = False
-    :type header: bool
-    :rtype: A generator of ``Documents``.
     """
 
     def __init__(
@@ -31,6 +20,18 @@ class TSVDocPreprocessor(DocPreprocessor):
         max_docs: int = sys.maxsize,
         header: bool = False,
     ) -> None:
+        """
+        :param path: a path to file or directory, or a glob pattern. The basename
+            (as returned by ``os.path.basename``) should be unique among all files.
+        :type path: str
+        :param encoding: file encoding to use (e.g. "utf-8").
+        :type encoding: str
+        :param max_docs: the maximum number of ``Documents`` to produce.
+        :type max_docs: int
+        :param header: if the TSV file contain header or not. default = False
+        :type header: bool
+        :rtype: A generator of ``Documents``.
+        """
         super().__init__(path, encoding, max_docs)
         self.header = header
 


### PR DESCRIPTION
Describe a glob pattern as an acceptable form of a path, and describes the unique basename requirement.

`DocPreprocessor` has 5 subclasses and 2 of them (`HTMLDocPreprocessor` and `TextDocPreprocessor`)
inherit the __init__ method. To reduce the maintainance cost, autoclass_content = "both"
has been enabled so that these two subclasses's `__init__` docstring also inherits from their parent.
see below for more details of autoclass_content
https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autoclass_content

Fix #414.
Close #415.