### PR TITLE
Fix minimum range difference for cols/rows in case of negative numbers

### DIFF
--- a/src/fonduer/utils/utils_table.py
+++ b/src/fonduer/utils/utils_table.py
@@ -23,7 +23,8 @@ def _min_range_diff(
             for ii in itertools.product(
                 list(range(a_start, a_end + 1)), list(range(b_start, b_end + 1))
             )
-        ]
+        ],
+        key=abs
     )
 
 


### PR DESCRIPTION
Currently a difference of -2 column/row steps will override a difference of 1 or 0.
This leads to wrong behaviour e.g. in for fields that span multiple columns/rows.

Closes #413