### PR TITLE
Fix minimum range difference for cols/rows in case of negative numbers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Changed
 ^^^^^^^
 * `@HiromuHota`_: Enabled "Type hints (PEP 484) support for the Sphinx autodoc extension."
 
+Fixed
+^^^^^
+* `@kaikun213`_: Fix bug in table range difference calculations.
+  (`#420 <https://github.com/HazyResearch/fonduer/pull/420>`_)
+
 0.8.2_ - 2020-04-28
 -------------------
 
@@ -1149,9 +1154,10 @@ Added
 ..
   For convenience, all username links for contributors can be listed here
 
-.. _@lukehsiao: https://github.com/lukehsiao
-.. _@senwu: https://github.com/senwu
-.. _@prabh06: https://github.com/Prabh06
 .. _@HiromuHota: https://github.com/HiromuHota
-.. _@j-rausch: https://github.com/j-rausch
 .. _@KenSugimoto: https://github.com/KenSugimoto
+.. _@j-rausch: https://github.com/j-rausch
+.. _@kaikun213: https://github.com/kaikun213
+.. _@lukehsiao: https://github.com/lukehsiao
+.. _@prabh06: https://github.com/Prabh06
+.. _@senwu: https://github.com/senwu

--- a/src/fonduer/utils/utils_table.py
+++ b/src/fonduer/utils/utils_table.py
@@ -23,7 +23,8 @@ def _min_range_diff(
             for ii in itertools.product(
                 list(range(a_start, a_end + 1)), list(range(b_start, b_end + 1))
             )
-        ]
+        ],
+        key=abs,
     )
 
 

--- a/tests/utils/test_utils_table.py
+++ b/tests/utils/test_utils_table.py
@@ -1,0 +1,17 @@
+import logging
+
+from fonduer.utils.utils_table import _min_range_diff
+
+
+def test_min_range_diff(caplog):
+    """Test the minimum range calculation for table utils."""
+    caplog.set_level(logging.INFO)
+
+    assert _min_range_diff(0, 5, 0, 5) == 0
+    assert _min_range_diff(1, 5, 3, 6) == 0
+    assert _min_range_diff(1, 2, 2, 3) == 0
+    assert _min_range_diff(3, 6, 1, 4) == 0
+    assert _min_range_diff(1, 2, 3, 4) == 1
+    assert _min_range_diff(3, 4, 1, 2) == 1
+    assert _min_range_diff(3, 4, 1, 2, absolute=False) == 1
+    assert _min_range_diff(1, 2, 3, 4, absolute=False) == -1


### PR DESCRIPTION
Currently a difference of -2 column/row steps will override a difference of 1 or 0.
This leads to wrong behavior e.g. in for fields that span multiple columns/rows.

Closes #413