### PR TITLE
Enabled "Type hints (PEP 484) support for the Sphinx autodoc extension"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Unreleased_
 -----------
 
+Changed
+^^^^^^^
+* `@HiromuHota`_: Enabled "Type hints (PEP 484) support for the Sphinx autodoc extension."
+
 0.8.2_ - 2020-04-28
 -------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,11 @@ release = ""
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx_autodoc_typehints",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pre-commit
 pytest
 sphinx
 sphinx_rtd_theme
+sphinx_autodoc_typehints


### PR DESCRIPTION
With this PR, the Sphinx docs would look nicer because type hints migrate from the method signature to each parameter.

Now:
![image](https://user-images.githubusercontent.com/20668349/82471913-3855f100-9a7c-11ea-9498-681eec28014f.png)


With this PR:
![image](https://user-images.githubusercontent.com/20668349/82471881-2ecc8900-9a7c-11ea-93d9-a068e1b5a6fa.png)
