### PR TITLE
Add get_bbox() to Sentence and (Temporary)SpanMention, and deprecate bbox_from_span and bbox_from_sentence

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,19 @@
 Unreleased_
 -----------
 
+Added
+^^^^^
+* `@HiromuHota`_: Add get_bbox() to :class:`Sentence` and :class:`SpanMention`.
+  (`#429 <https://github.com/HazyResearch/fonduer/pull/429>`_)
+
 Changed
 ^^^^^^^
 * `@HiromuHota`_: Enabled "Type hints (PEP 484) support for the Sphinx autodoc extension."
+
+Deprecated
+^^^^^^^^^^
+* `@HiromuHota`_: Deprecated :func:`bbox_from_span` and :func:`bbox_from_sentence`.
+  (`#429 <https://github.com/HazyResearch/fonduer/pull/429>`_)
 
 Fixed
 ^^^^^

--- a/src/fonduer/candidates/models/span_mention.py
+++ b/src/fonduer/candidates/models/span_mention.py
@@ -8,6 +8,7 @@ from fonduer.candidates.models.temporary_context import TemporaryContext
 from fonduer.parser.models.context import Context
 from fonduer.parser.models.sentence import Sentence
 from fonduer.parser.models.utils import construct_stable_id
+from fonduer.utils.utils_visual import Bbox
 
 
 class TemporarySpanMention(TemporaryContext):
@@ -172,6 +173,19 @@ class TemporarySpanMention(TemporaryContext):
         :rtype: str
         """
         return self.get_attrib_span("words")
+
+    def get_bbox(self) -> Bbox:
+        """Get the bounding box."""
+        if self.sentence.is_visual():
+            return Bbox(
+                self.get_attrib_tokens("page")[0],
+                min(self.get_attrib_tokens("top")),
+                max(self.get_attrib_tokens("bottom")),
+                min(self.get_attrib_tokens("left")),
+                max(self.get_attrib_tokens("right")),
+            )
+        else:
+            return None
 
     def __contains__(self, other_span: object) -> bool:
         if not isinstance(other_span, TemporarySpanMention):

--- a/src/fonduer/parser/models/sentence.py
+++ b/src/fonduer/parser/models/sentence.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import backref, relationship
 
 from fonduer.parser.models.context import Context
+from fonduer.utils.utils_visual import Bbox
 
 INT_ARRAY_TYPE = postgresql.ARRAY(Integer)
 STR_ARRAY_TYPE = postgresql.ARRAY(String)
@@ -167,6 +168,21 @@ class VisualMixin(object):
         :rtype: bool
         """
         return self.page is not None and self.page[0] is not None
+
+    def get_bbox(self) -> Bbox:
+        """Get the bonding box."""
+        # TODO: this may have issues where a sentence is linked to words on different
+        # pages
+        if self.is_visual():
+            return Bbox(
+                self.page[0],
+                min(self.top),
+                max(self.bottom),
+                min(self.left),
+                max(self.right),
+            )
+        else:
+            return None
 
 
 class StructuralMixin(object):

--- a/src/fonduer/utils/data_model_utils/visual.py
+++ b/src/fonduer/utils/data_model_utils/visual.py
@@ -253,10 +253,7 @@ def _get_direction_ngrams(
             continue
         for sentence in span.sentence.document.sentences:
             # Skip if not in the same page.
-            if (
-                bbox_from_sentence(span.sentence).page
-                != bbox_from_sentence(sentence).page
-            ):
+            if span.sentence.get_bbox().page != bbox_from_sentence(sentence).page:
                 continue
             if from_sentence:
                 if (

--- a/src/fonduer/utils/data_model_utils/visual.py
+++ b/src/fonduer/utils/data_model_utils/visual.py
@@ -436,10 +436,10 @@ def _preprocess_visual_features(doc: Document) -> None:
         x1_aligned: DefaultDict[int, List[Sentence]] = defaultdict(list)
         for sentence in sentences:
             sentence.bbox = bbox_from_sentence(sentence)
-            sentence.yc = (sentence.bbox.top + sentence.bbox.bottom) / 2
+            sentence.yc = int((sentence.bbox.top + sentence.bbox.bottom) / 2)
             sentence.x0 = sentence.bbox.left
             sentence.x1 = sentence.bbox.right
-            sentence.xc = (sentence.x0 + sentence.x1) / 2
+            sentence.xc = int((sentence.x0 + sentence.x1) / 2)
             # index current sentence by different alignment keys
             yc_aligned[sentence.yc].append(sentence)
             x0_aligned[sentence.x0].append(sentence)

--- a/src/fonduer/utils/data_model_utils/visual.py
+++ b/src/fonduer/utils/data_model_utils/visual.py
@@ -5,7 +5,7 @@
 from builtins import range
 from collections import defaultdict
 from functools import lru_cache
-from typing import DefaultDict, Iterator, List, Set, Union
+from typing import Any, DefaultDict, Iterator, List, Set, Union
 
 from fonduer.candidates.mentions import Ngrams
 from fonduer.candidates.models import Candidate, Mention
@@ -421,10 +421,10 @@ def _preprocess_visual_features(doc: Document) -> None:
 
     for page, sentences in sentence_by_page.items():
         # process per page alignments
-        yc_aligned: DefaultDict[int, List[Sentence]] = defaultdict(list)
-        x0_aligned: DefaultDict[int, List[Sentence]] = defaultdict(list)
-        xc_aligned: DefaultDict[int, List[Sentence]] = defaultdict(list)
-        x1_aligned: DefaultDict[int, List[Sentence]] = defaultdict(list)
+        yc_aligned: DefaultDict[Any, List[Sentence]] = defaultdict(list)
+        x0_aligned: DefaultDict[Any, List[Sentence]] = defaultdict(list)
+        xc_aligned: DefaultDict[Any, List[Sentence]] = defaultdict(list)
+        x1_aligned: DefaultDict[Any, List[Sentence]] = defaultdict(list)
         for sentence in sentences:
             sentence.bbox = sentence.get_bbox()
             sentence.yc = (sentence.bbox.top + sentence.bbox.bottom) / 2

--- a/src/fonduer/utils/data_model_utils/visual.py
+++ b/src/fonduer/utils/data_model_utils/visual.py
@@ -427,10 +427,10 @@ def _preprocess_visual_features(doc: Document) -> None:
         x1_aligned: DefaultDict[int, List[Sentence]] = defaultdict(list)
         for sentence in sentences:
             sentence.bbox = sentence.get_bbox()
-            sentence.yc = int((sentence.bbox.top + sentence.bbox.bottom) / 2)
+            sentence.yc = (sentence.bbox.top + sentence.bbox.bottom) / 2
             sentence.x0 = sentence.bbox.left
             sentence.x1 = sentence.bbox.right
-            sentence.xc = int((sentence.x0 + sentence.x1) / 2)
+            sentence.xc = (sentence.x0 + sentence.x1) / 2
             # index current sentence by different alignment keys
             yc_aligned[sentence.yc].append(sentence)
             x0_aligned[sentence.x0].append(sentence)

--- a/src/fonduer/utils/utils_visual.py
+++ b/src/fonduer/utils/utils_visual.py
@@ -1,7 +1,5 @@
+import warnings
 from typing import NamedTuple
-
-from fonduer.candidates.models.span_mention import TemporarySpanMention
-from fonduer.parser.models import Sentence
 
 
 class Bbox(NamedTuple):
@@ -14,7 +12,13 @@ class Bbox(NamedTuple):
     right: int
 
 
-def bbox_from_span(span: TemporarySpanMention) -> Bbox:
+def bbox_from_span(span) -> Bbox:  # type: ignore
+    warnings.warn(
+        "bbox_from_span(span) is deprecated. Use span.get_bbox() instead.",
+        DeprecationWarning,
+    )
+    from fonduer.candidates.models.span_mention import TemporarySpanMention  # noqa
+
     if isinstance(span, TemporarySpanMention) and span.sentence.is_visual():
         return Bbox(
             span.get_attrib_tokens("page")[0],
@@ -27,7 +31,13 @@ def bbox_from_span(span: TemporarySpanMention) -> Bbox:
         return None
 
 
-def bbox_from_sentence(sentence: Sentence) -> Bbox:
+def bbox_from_sentence(sentence) -> Bbox:  # type: ignore
+    warnings.warn(
+        "bbox_from_sentence(sentence) is deprecated. Use sentence.get_bbox() instead.",
+        DeprecationWarning,
+    )
+    from fonduer.parser.models import Sentence  # noqa
+
     # TODO: this may have issues where a sentence is linked to words on different pages
     if isinstance(sentence, Sentence) and sentence.is_visual():
         return Bbox(

--- a/src/fonduer/utils/utils_visual.py
+++ b/src/fonduer/utils/utils_visual.py
@@ -1,9 +1,17 @@
-from collections import namedtuple
+from typing import NamedTuple
 
 from fonduer.candidates.models.span_mention import TemporarySpanMention
 from fonduer.parser.models import Sentence
 
-Bbox = namedtuple("bbox", ["page", "top", "bottom", "left", "right"])
+
+class Bbox(NamedTuple):
+    """Bounding box."""
+
+    page: int
+    top: int
+    bottom: int
+    left: int
+    right: int
 
 
 def bbox_from_span(span: TemporarySpanMention) -> Bbox:

--- a/src/fonduer/utils/visualizer.py
+++ b/src/fonduer/utils/visualizer.py
@@ -13,6 +13,7 @@ from wand.image import Image
 
 from fonduer.candidates.models import Candidate, SpanMention
 from fonduer.parser.models import Sentence
+from fonduer.utils.utils_visual import Bbox
 
 logger = logging.getLogger(__name__)
 
@@ -28,10 +29,7 @@ class Visualizer(object):
         self.pdf_path = pdf_path
 
     def display_boxes(
-        self,
-        pdf_file: str,
-        boxes: List[Tuple[int, int, int, int, int]],
-        alternate_colors: bool = False,
+        self, pdf_file: str, boxes: List[Bbox], alternate_colors: bool = False,
     ) -> List[Image]:
         """
         Displays each of the bounding boxes passed in 'boxes' on images of the pdf
@@ -94,7 +92,7 @@ class Visualizer(object):
             for i, word in enumerate(sentence.words):
                 if target is None or word == target:
                     boxes.append(
-                        (
+                        Bbox(
                             sentence.page[i],
                             sentence.top[i],
                             sentence.left[i],
@@ -106,15 +104,15 @@ class Visualizer(object):
         return display(*imgs)
 
 
-def get_box(span: SpanMention) -> Tuple[int, int, int, int, int]:
-    box = (
+def get_box(span: SpanMention) -> Bbox:
+    """Get the bounding box."""
+    return Bbox(
         min(span.get_attrib_tokens("page")),
         min(span.get_attrib_tokens("top")),
         min(span.get_attrib_tokens("left")),
         max(span.get_attrib_tokens("bottom")),
         max(span.get_attrib_tokens("right")),
     )
-    return box
 
 
 def get_pdf_dim(pdf_file: str, page: int = 1) -> Tuple[int, int]:


### PR DESCRIPTION
This PR has two benefits:
1. Type hints become short, hence easier to understand: `Tuple[int, int, int, int, int]` to `Bbox`.
2. No need to import `bbox_from_sentence` and `bbox_from_span`. Just use `sentence.get_bbox()` and `span.get_bbox()`. This is actually the benefit from using OOP.

P.S. There are many more spots where OOP (object-oriented programming) is more suited.