### PR TITLE
Run DocPreprocessor._parse_file only once

### DIFF
--- a/src/fonduer/utils/udf.py
+++ b/src/fonduer/utils/udf.py
@@ -62,9 +62,6 @@ class UDFRunner(object):
         if clear:
             self.clear(**kwargs)
 
-        # Track the last documents parsed by apply
-        self.last_docs = set(doc.name for doc in doc_loader)
-
         # Execute the UDF
         self.logger.info("Running UDF...")
 
@@ -112,9 +109,12 @@ class UDFRunner(object):
         # Use an output queue to track multiprocess progress
         out_queue = manager.Queue()
 
+        # Clear the last documents parsed by the last run
+        self.last_docs = set()
         # Fill input queue with documents
         for doc in doc_loader:
             in_queue.put(doc)
+            self.last_docs.add(doc.name)
         total_count = in_queue.qsize()
 
         # Create UDF Processes


### PR DESCRIPTION
When `doc_loader` is an instance of `DocPreprocessor` or of its child class, `_parse_file` is executed during iteration (the for-loop in this case).
The current implementation iterates `doc_loader` twice (once for `self.last_docs` and another for `in_queue.put(doc)`.
This PR is to run `_parse_file` only once for better computational efficiency.