### PR TITLE
Execute preprocessing and parsing in parallel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,9 @@ Fixed
 * `@HiromuHota`_: Fix the non-deterministic behavior in VisualLinker.
   (`#412 <https://github.com/HazyResearch/fonduer/issues/412>`_)
   (`#458 <https://github.com/HazyResearch/fonduer/pull/458>`_)
+* `@HiromuHota`_: Fix an issue that the progress bar shows no progress on preprocessing
+  by executing preprocessing and parsing in parallel.
+  (`#439 <https://github.com/HazyResearch/fonduer/pull/439>`_)
 
 0.8.2_ - 2020-04-28
 -------------------


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

Currently, preprocessor and parser are executed in a complete sequential order.
i.e., preprocess N docs (and load them into a queue), then parse N docs.
This has two drawbacks:
  1. the progress bar shows nothing during preprocessing.
  2. the machine RAM has to be large enough to hold N preprocessed docs at a time.

They become more serious when N is large and/or each HTML file is large.

**Does your pull request fix any issue.**

Fix #435 

## Description of the proposed changes
A clear and concise description of what you propose.

This PR
- places a cap on the `in_queue` so that only a certain number of documents are loaded to `in_queue`.
- executes preprocessor and parser in parallel (ie the main process does preprocessing and child process(es) do parsing in parallel).

## Test plan
A clear and concise description of how you test the new changes.

For the 1st issue: I manually check the progress bar starts showing progress right after starting `parse.apply`.

## Checklist

* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.rst accordingly.