### PR TITLE
Sort by block top, block left, top, then left

### DIFF
--- a/src/fonduer/parser/visual_linker.py
+++ b/src/fonduer/parser/visual_linker.py
@@ -173,7 +173,7 @@ class VisualLinker(object):
         pdf_word_list = sorted(
             pdf_word_list,
             key=lambda word_id__: block_coordinates[word_id__[0]]
-            + coordinate_map[word_id__[0]][1:3],
+            + (coordinate_map[word_id__[0]].top, coordinate_map[word_id__[0]].left),
         )
         return pdf_word_list, coordinate_map
 

--- a/src/fonduer/parser/visual_linker.py
+++ b/src/fonduer/parser/visual_linker.py
@@ -210,7 +210,9 @@ class VisualLinker(object):
 
         def link_exact(l: int, u: int) -> None:
             l, u, L, U = get_anchors(l, u)
+            # Inverted index that maps word to index(es) of html_word_list
             html_dict: DefaultDict[str, List[int]] = defaultdict(list)
+            # Inverted index that maps word to index(es) of pdf_word_list
             pdf_dict: DefaultDict[str, List[int]] = defaultdict(list)
             for i, (_, word) in enumerate(self.html_word_list[l:u]):
                 if html_to_pdf[l + i] is None:

--- a/tests/data/html_simple/no_image_unsorted.html
+++ b/tests/data/html_simple/no_image_unsorted.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title></title>
+<meta name="Creator" content="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36"/>
+<meta name="Producer" content="Skia/PDF m81"/>
+<meta name="CreationDate" content=""/>
+</head>
+<body>
+<doc>
+  <page width="594.959960" height="841.919980">
+    <flow>
+      <block xMin="6.002521" yMin="49.327362" xMax="244.051738" yMax="80">
+        <line xMin="6.002521" yMin="49.327362" xMax="244.051738" yMax="80">
+          <word xMin="101.702879" yMin="70" xMax="117.705695" yMax="80">has</word>
+          <word xMin="120.706955" yMin="70" xMax="126.035366" yMax="80">a</word>
+          <word xMin="129.036626" yMin="70" xMax="157.701011" yMax="80">figure</word>
+          <word xMin="160.702272" yMin="70" xMax="197.385650" yMax="80">without</word>
+          <word xMin="200.386911" yMin="70" xMax="211.717843" yMax="80">an</word>
+          <word xMin="214.719103" yMin="70" xMax="244.051738" yMax="80">image</word>
+          <word xMin="6.002521" yMin="49.327362" xMax="27.345471" yMax="62.622009">This</word>
+          <word xMin="30.346732" yMin="49.327362" xMax="38.354002" yMax="62.622009">is</word>
+          <word xMin="41.355263" yMin="49.327362" xMax="52.686194" yMax="62.622009">an</word>
+          <word xMin="55.687455" yMin="49.327362" xMax="77.698654" yMax="62.622009">html</word>
+          <word xMin="80.699915" yMin="49.327362" xMax="98.701618" yMax="62.622009">that</word>
+        </line>
+      </block>
+      <block xMin="6.002521" yMin="6.365955" xMax="161.411554" yMax="32.955250">
+        <line xMin="6.002521" yMin="6.365955" xMax="161.411554" yMax="32.955250">
+          <word xMin="88.044797" yMin="6.365955" xMax="161.411554" yMax="32.955250">HTML</word>
+          <word xMin="6.002521" yMin="6.365955" xMax="82.042276" yMax="32.955250">Sample</word>
+        </line>
+      </block>
+    </flow>
+  </page>
+</doc>
+</body>
+</html>


### PR DESCRIPTION
By #444, the sort keys were block top, block left, top, then **bottom**.
However, it should be block top, block left, top, then **left** as indicated by the following comment.
> sort pdf_word_list by page, block top then block left, top, then left

This PR will fix this issue.

Actually, #444 should have failed. This PR needs a unit test that would fail on #444.