### PR TITLE
Fix the non-deterministic behavior in VisualLinker

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,9 @@ Fixed
 * `@HiromuHota`_: Fix the order of args to Bbox.
   (`#443 <https://github.com/HazyResearch/fonduer/issues/443>`_)
   (`#444 <https://github.com/HazyResearch/fonduer/pull/444>`_)
+* `@HiromuHota`_: Fix the non-deterministic behavior in VisualLinker.
+  (`#412 <https://github.com/HazyResearch/fonduer/issues/412>`_)
+  (`#458 <https://github.com/HazyResearch/fonduer/pull/458>`_)
 
 0.8.2_ - 2020-04-28
 -------------------

--- a/src/fonduer/parser/visual_linker.py
+++ b/src/fonduer/parser/visual_linker.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 from builtins import object, range, zip
 from collections import OrderedDict, defaultdict
+from operator import attrgetter
 from typing import DefaultDict, Dict, Iterator, List, Optional, Tuple
 
 import numpy as np
@@ -63,7 +64,8 @@ class VisualLinker(object):
             override the one used in initialization, if provided.
         :return: A generator of ``Sentence``.
         """
-        self.sentences = sentences
+        # sentences should be sorted as their order is not deterministic.
+        self.sentences = sorted(sentences, key=attrgetter("position"))
         self.pdf_file = (
             pdf_path if os.path.isfile(pdf_path) else pdf_path + document_name + ".pdf"
         )

--- a/tests/parser/test_visual_linker.py
+++ b/tests/parser/test_visual_linker.py
@@ -1,0 +1,54 @@
+"""Fonduer visual_linker unit tests."""
+import random
+from operator import attrgetter
+
+from fonduer.parser.preprocessors import HTMLDocPreprocessor
+from fonduer.parser.visual_linker import VisualLinker
+from tests.parser.test_parser import get_parser_udf
+
+
+def test_visual_linker_not_affected_by_order_of_sentences():
+    """Test if visual_linker result is not affected by the order of sentences."""
+    docs_path = "tests/data/html/2N6427.html"
+    pdf_path = "tests/data/pdf/2N6427.pdf"
+
+    # Initialize preprocessor, parser, visual_linker.
+    # Note that parser is initialized with `visual=False` and that visual_linker
+    # will be used to attach "visual" information to sentences after parsing.
+    preprocessor = HTMLDocPreprocessor(docs_path)
+    parser_udf = get_parser_udf(
+        structural=True, lingual=False, tabular=True, visual=False
+    )
+    visual_linker = VisualLinker(pdf_path=pdf_path)
+
+    doc = parser_udf.apply(next(preprocessor.__iter__()))
+    # Sort sentences by sentence.position
+    doc.sentences = sorted(doc.sentences, key=attrgetter("position"))
+    sentences0 = [
+        sent for sent in visual_linker.link(doc.name, doc.sentences, pdf_path)
+    ]
+    # Sort again in case visual_linker.link changes the order
+    sentences0 = sorted(sentences0, key=attrgetter("position"))
+
+    doc = parser_udf.apply(next(preprocessor.__iter__()))
+    # Shuffle
+    random.shuffle(doc.sentences)
+    sentences1 = [
+        sent for sent in visual_linker.link(doc.name, doc.sentences, pdf_path)
+    ]
+    # Sort sentences by sentence.position
+    sentences1 = sorted(sentences1, key=attrgetter("position"))
+
+    # This should hold as both sentences are sorted by their position
+    assert all(
+        [
+            sent0.position == sent1.position
+            for (sent0, sent1) in zip(sentences0, sentences1)
+        ]
+    )
+
+    # The following assertion should hold if the visual_linker result is not affected
+    # by the order of sentences.
+    assert all(
+        [sent0.left == sent1.left for (sent0, sent1) in zip(sentences0, sentences1)]
+    )


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

See #412.

**Does your pull request fix any issue.**

Fix #412.

## Description of the proposed changes
A clear and concise description of what you propose.

Based on my findings reported at #412, the non-deterministic behaviour in `Featurization` boils down to a non-deterministic behaviour in `VisualLinker`, which is caused by the fact that the order of `doc.sentences` is not deterministic unless `order_by=True` in the `backref` argument below.
https://github.com/HazyResearch/fonduer/blob/246a92dd05884e3a706ba216e6177456d537de13/src/fonduer/parser/models/sentence.py#L248-L252
One trivial way to fix this issue is to add `order_by=True` to the `backref`, however, I just sort `sentences` (by position) at the beginning of `VisualLinker.link` and I think this is good enough to fix #412.

## Test plan
A clear and concise description of how you test the new changes.

Ideally, I'd like to test if my change prevents #412 from happening.
However, this is not feasible as the issue is **non-deterministic** and does not happen every test run.
Instead, I'd test if the result of visual linker is affected by the order of sentences.

## Checklist

* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.rst accordingly.
