### PR TITLE
Adopt to mlflow >= 1.9.0

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -6,4 +6,4 @@ force_grid_wrap=0
 combine_as_imports=True
 line_length=88
 known_first_party = fonduer,tests
-known_third_party = IPython,bs4,cloudpickle,editdistance,emmental,lxml,mlflow,numpy,pandas,pytest,scipy,setuptools,snorkel,spacy,sqlalchemy,tensorboardX,torch,treedlib,wand,yaml
+known_third_party = IPython,bs4,cloudpickle,editdistance,emmental,lxml,mlflow,numpy,packaging,pandas,pytest,scipy,setuptools,snorkel,spacy,sqlalchemy,tensorboardX,torch,treedlib,wand,yaml

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,9 @@ Fixed
 * `@HiromuHota`_: Fix an issue that the progress bar shows no progress on preprocessing
   by executing preprocessing and parsing in parallel.
   (`#439 <https://github.com/HazyResearch/fonduer/pull/439>`_)
+* `@HiromuHota`_: Adopt to mlflow>=1.9.0.
+  (`#461 <https://github.com/HazyResearch/fonduer/issues/461>`_)
+  (`#463 <https://github.com/HazyResearch/fonduer/pull/463>`_)
 
 0.8.2_ - 2020-04-28
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "snorkel>=0.9.5, <0.10.0",  # placed early due to stricter requirements
         "emmental>=0.0.6, <0.1.0",
         "lxml>=4.2.5, <5.0.0",
-        "mlflow>=1.1.0, <1.9.0",
+        "mlflow>=1.1.0, <2.0.0",
         "numpy>=1.11, <2.0",
         "pyyaml>=5.1, <6.0",
         "scipy>=1.1.0, <2.0.0",

--- a/tests/packaging/test_fonduer_model.py
+++ b/tests/packaging/test_fonduer_model.py
@@ -12,6 +12,7 @@ import pandas as pd
 import pytest
 import yaml
 from emmental.model import EmmentalModel
+from packaging import version
 from snorkel.labeling.model import LabelModel
 
 from fonduer.candidates import CandidateExtractor, MentionExtractor
@@ -283,7 +284,10 @@ def test_predict(mocker, setup_common_components: Dict):
     fonduer_model._classify = MagicMock(return_value=mock_output)
 
     # Input both html_path and pdf_html
-    spy = mocker.spy(fonduer_model, "_process")
+    if version.parse(mlflow.__version__) >= version.parse("1.9.0"):
+        spy = mocker.spy(fonduer_model._model_impl, "_process")
+    else:
+        spy = mocker.spy(fonduer_model, "_process")
     output = fonduer_model.predict(
         pd.DataFrame(
             data={

--- a/tests/packaging/test_fonduer_model.py
+++ b/tests/packaging/test_fonduer_model.py
@@ -281,12 +281,13 @@ def test_predict(mocker, setup_common_components: Dict):
 
     # Mock the _classify as we don't test the implementation of _classify here.
     mock_output = pd.DataFrame(data={"col1": ["val1"], "col2": ["val2"]})
-    fonduer_model._classify = MagicMock(return_value=mock_output)
 
     # Input both html_path and pdf_html
     if version.parse(mlflow.__version__) >= version.parse("1.9.0"):
+        fonduer_model._model_impl._classify = MagicMock(return_value=mock_output)
         spy = mocker.spy(fonduer_model._model_impl, "_process")
     else:
+        fonduer_model._classify = MagicMock(return_value=mock_output)
         spy = mocker.spy(fonduer_model, "_process")
     output = fonduer_model.predict(
         pd.DataFrame(
@@ -335,7 +336,10 @@ def test_predict(mocker, setup_common_components: Dict):
 
     # Test when _classify produces multiple relations per doc.
     mock_output = pd.DataFrame(data={"col0": ["00", "10"], "col1": ["01", "11"]})
-    fonduer_model._classify = MagicMock(return_value=mock_output)
+    if version.parse(mlflow.__version__) >= version.parse("1.9.0"):
+        fonduer_model._model_impl._classify = MagicMock(return_value=mock_output)
+    else:
+        fonduer_model._classify = MagicMock(return_value=mock_output)
     output = fonduer_model.predict(
         pd.DataFrame(data={"html_path": ["tests/data/html/112823.html"]})
     )


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**
A clear and concise description of what the problem is.

See #461.

**Does your pull request fix any issue.**

Fix #461.

## Description of the proposed changes
A clear and concise description of what you propose.

In Fonduer, `FonduerModel._process` and `FonduerModel._classify` have been spied and mocked, respectively, for testing purpose.
However, as of MLflow v1.9.0, a PyFunc model (e.g., `HardwareFonduerModel`) is now wrapped by `mlflow.pyfunc.PyFuncModel` (mlflow/mlflow#2920) and can only be accessed by its `_model_impl` attribute.
This PR spies and mocks on `_model_impl` attribute if mlflow>=1.9.0.

## Test plan
A clear and concise description of how you test the new changes.

No new test plan. I just fixed existing tests so they work with both mlflow<1.9.0 and >=1.9.0.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.rst accordingly.
