### PR TITLE
Do not explicitly try to install freetype, which is already installed

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -93,13 +93,11 @@ jobs:
         command: |
           pip install -U pip  # upgrade pip after installing python
           echo "::add-path::`pyenv root`/shims"
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v2
     - name: Install dependencies for macOS
       run: |
         brew update
         # Install ImageMagick for Wand.
-        brew install freetype imagemagick ghostscript
+        brew install imagemagick
 
         brew install poppler
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -93,6 +93,8 @@ jobs:
         command: |
           pip install -U pip  # upgrade pip after installing python
           echo "::add-path::`pyenv root`/shims"
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v2
     - name: Install dependencies for macOS
       run: |
         brew update


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

See #467.

**Does your pull request fix any issue.**

Fix #467.

## Description of the proposed changes

Do not explicitly try to install `freetype` (and `ghostscript`) to prevent "Error: freetype 2.10.1 is already installed" from happening.

## Test plan

No change in the test.
This PR actually fixes the test environment.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [ ] I have updated the CHANGELOG.rst accordingly.
