### PR TITLE
Correct the entity type for NumberMatcher from “NUMBER” to “CARDINAL”

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,6 +58,9 @@ Fixed
 * `@HiromuHota`_: Adopt to mlflow>=1.9.0.
   (`#461 <https://github.com/HazyResearch/fonduer/issues/461>`_)
   (`#463 <https://github.com/HazyResearch/fonduer/pull/463>`_)
+* `@HiromuHota`_: Correct the entity type for NumberMatcher from "NUMBER" to "CARDINAL".
+  (`#473 <https://github.com/HazyResearch/fonduer/issues/473>`_)
+  (`#477 <https://github.com/HazyResearch/fonduer/pull/477>`_)
 
 0.8.2_ - 2020-04-28
 -------------------

--- a/src/fonduer/candidates/matchers.py
+++ b/src/fonduer/candidates/matchers.py
@@ -455,13 +455,13 @@ class NumberMatcher(RegexMatchEach):
     Match Spans that are numbers, as identified by spaCy.
 
     A convenience class for setting up a RegexMatchEach to match spans
-    for which each token was tagged as a number (NUMBER or QUANTITY).
+    for which each token was tagged as a number (CARDINAL or QUANTITY).
     """
 
     def __init__(self, *children, **kwargs):  # type: ignore
         """Initialize number matcher."""
         kwargs["attrib"] = "ner_tags"
-        kwargs["rgx"] = "NUMBER|QUANTITY"
+        kwargs["rgx"] = "CARDINAL|QUANTITY"
         super().__init__(*children, **kwargs)
 
 

--- a/tests/candidates/test_matchers.py
+++ b/tests/candidates/test_matchers.py
@@ -358,8 +358,7 @@ def test_ner_matchers():
         "O",
     ]
     doc.sentences[1].ner_tags = ["O", "O", "O", "O", "O", "ORG", "O"]
-    # TODO: replace "NUMBER" with "CARDINAL" (#473)
-    doc.sentences[2].ner_tags = ["O", "O", "NUMBER", "NUMBER", "O", "MISC", "O"]
+    doc.sentences[2].ner_tags = ["O", "O", "CARDINAL", "CARDINAL", "O", "MISC", "O"]
 
     # the length of words and that of ner_tags should match.
     assert len(doc.sentences[0].words) == len(doc.sentences[0].ner_tags)


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

See #473

**Does your pull request fix any issue.**

Fix #473

## Description of the proposed changes

Use "CARDINAL" instead of "NUMBER", which is not supported entity type by spaCy

## Test plan

`tests/candidates/test_matchers.py` was updated accordingly.

## Checklist

* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.rst accordingly.
