### PR TITLE
Log a stack trace on parsing error for better debug experience

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,9 @@ Changed
   Since the Japanese tokenizer remains the same, there should be no impact on users.
   (`#384 <https://github.com/HazyResearch/fonduer/issues/384>`_)
   (`#432 <https://github.com/HazyResearch/fonduer/pull/432>`_)
+* `@HiromuHota`_: Log a stack trace on parsing error for better debug experience.
+  (`#478 <https://github.com/HazyResearch/fonduer/issues/478>`_)
+  (`#479 <https://github.com/HazyResearch/fonduer/pull/479>`_)
 
 Deprecated
 ^^^^^^^^^^

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -281,7 +281,7 @@ class ParserUDF(UDF):
                     ]
             return document
         except Exception as e:
-            warnings.warn(
+            logging.exception(
                 (
                     f"Document {document.name} not added to database, "
                     f"because of parse error: \n{e}"


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

See #478.

**Does your pull request fix any issue.**

Fix #478.

## Description of the proposed changes

Use `logging.exception()` instead of `warnings.warn()` to show a stack trace.

## Test plan

Running `pytest tests/parser/test_parser.py::test_parse_error_doc_skipping` with `log_cli = true` can show you detailed message.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.rst accordingly.
