### PR TITLE
Fix get_axis_ngrams not to return None

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,6 +64,8 @@ Fixed
 * `@HiromuHota`_: Correct the entity type for NumberMatcher from "NUMBER" to "CARDINAL".
   (`#473 <https://github.com/HazyResearch/fonduer/issues/473>`_)
   (`#477 <https://github.com/HazyResearch/fonduer/pull/477>`_)
+* `@HiromuHota`_: Fix :func:`_get_axis_ngrams` not to return ``None`` when the input is not tabular.
+  (`#481 <https://github.com/HazyResearch/fonduer/pull/481>`_)
 
 0.8.2_ - 2020-04-28
 -------------------

--- a/src/fonduer/utils/data_model_utils/tabular.py
+++ b/src/fonduer/utils/data_model_utils/tabular.py
@@ -502,12 +502,12 @@ def _get_axis_ngrams(
     n_max: int = 1,
     spread: List[int] = [0, 0],
     lower: bool = True,
-) -> Iterator[Union[str, None]]:
+) -> Iterator[str]:
     span = _to_span(mention)
 
     if not span.sentence.is_tabular():
-        yield None
         return
+        yield
 
     for ngram in get_sentence_ngrams(
         span, attrib=attrib, n_min=n_min, n_max=n_max, lower=lower

--- a/tests/candidates/test_candidates.py
+++ b/tests/candidates/test_candidates.py
@@ -373,8 +373,8 @@ def test_row_col_ngram_extraction():
         row_ngrams = list(get_row_ngrams(mention))
         col_ngrams = list(get_col_ngrams(mention))
         if not mention.sentence.is_tabular():
-            assert len(row_ngrams) == 1 and row_ngrams[0] is None
-            assert len(col_ngrams) == 1 and col_ngrams[0] is None
+            assert len(row_ngrams) == 0
+            assert len(col_ngrams) == 0
         else:
             assert not any(x is None for x in row_ngrams)
             assert not any(x is None for x in col_ngrams)

--- a/tests/utils/data_model_utils/test_tabular.py
+++ b/tests/utils/data_model_utils/test_tabular.py
@@ -241,8 +241,7 @@ def test_get_col_ngrams(mention_setup):
 
     # when a mention is not tabular
     assert mentions[0].get_span() == "Sample"
-    # TODO: the return value [None] is inconsistent with others like get_cell_ngrams
-    assert list(get_col_ngrams(mentions[0])) == [None]
+    assert list(get_col_ngrams(mentions[0])) == []
 
 
 def test_get_aligned_ngrams(mention_setup):


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

When you use `get_row_ngrams` from `fonduer.utils.data_model_utils.tabular` like this
```python
from fonduer.utils.data_model_utils.tabular import get_row_ngrams
@labeling_function()
def LF_keyword_in_row_ngrams(c: Candidate) -> int:
    if any(['keyword' in ngram for ngram in get_row_ngrams(c)]):
        return TRUE
```

I'd expect `get_row_ngrams(c)` to return nothing when `c` is not tabular.

However, an error "TypeError: argument of type 'NoneType' is not iterable" will happen when `c` is not tabular.

**Does your pull request fix any issue.**

N/A.

## Description of the proposed changes

`get_row_ngrams` and similar utils functions like `get_col_ngrams` and `get_aligned_ngrams` return nothing (ie empty generator) when the input mention (or candidate) is not tabular.

## Test plan

The existing tests cover the corresponding part of the codes.
I adopted these tests to the change.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.rst accordingly.
