### PR TITLE
Do not access doc.name in in_thread to prevent concurrent session access

### DIFF
--- a/src/fonduer/utils/udf.py
+++ b/src/fonduer/utils/udf.py
@@ -131,7 +131,7 @@ class UDFRunner(object):
 
         # Fill input queue with documents but # of docs in queue is capped (#435).
         def in_thread_func() -> None:
-            # Do not use session here to prevent concurrent use (#485).
+            # Do not use session here to prevent concurrent use (#482).
             for doc in doc_loader:
                 in_queue.put(doc)  # block until a free slot is available
 

--- a/src/fonduer/utils/udf.py
+++ b/src/fonduer/utils/udf.py
@@ -129,8 +129,9 @@ class UDFRunner(object):
         for udf in self.udfs:
             udf.start()
 
+        # Fill input queue with documents but # of docs in queue is capped (#435).
         def in_thread_func() -> None:
-            # Fill input queue with documents but # of docs in queue is capped (#435).
+            # Do not use session here to prevent concurrent use (#485).
             for doc in doc_loader:
                 in_queue.put(doc)  # block until a free slot is available
 


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

See #482.

**Does your pull request fix any issue.**

Fix #482.

## Description of the proposed changes

This PR prevents concurrent session access, which is the root cause of #482.

## Test plan

The tests in this repository could not reproduce #482.
This is because #482 is a race-condition, while `test_e2e` uses only `max_docs = 12`, which turned out  not to be big enough to reproduce this issue.
The hardware tutorial uses `max_docs = 100` and can reproduce it (https://github.com/HiromuHota/fonduer-tutorials/runs/879864413).

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [ ] I have updated the CHANGELOG.rst accordingly.
