### PR TITLE
Fix `common_ancestor` to return the correct common ancestor for span mentions that share the exact same ancestor

### DIFF
--- a/src/fonduer/utils/data_model_utils/structural.py
+++ b/src/fonduer/utils/data_model_utils/structural.py
@@ -179,10 +179,13 @@ def common_ancestor(c: Tuple[SpanMention, ...]) -> List[str]:
     spans = [_to_span(i) for i in c]
     ancestors = [np.array(span.sentence.xpath.split("/")) for span in spans]
     min_len = min([a.size for a in ancestors])
-    arrays = np.array([a[:min_len] for a in ancestors])
-    arg_min = np.argmin(arrays[:-1] == arrays[1:], axis=1)
-    val = np.min(arg_min[np.nonzero(arg_min)])
-    return list(ancestors[0][:val])
+    ancestor = ancestors[0]
+    ind = 0  # all the ancestors are common up to this index (exclusive).
+    while ind < min_len:
+        if not all([a[ind] == ancestor[ind] for a in ancestors]):
+            break
+        ind += 1
+    return list(ancestors[0][:ind])
 
 
 def lowest_common_ancestor_depth(c: Tuple[SpanMention, ...]) -> int:
@@ -209,7 +212,10 @@ def lowest_common_ancestor_depth(c: Tuple[SpanMention, ...]) -> int:
     spans = [_to_span(i) for i in c]
     ancestors = [np.array(span.sentence.xpath.split("/")) for span in spans]
     min_len = min([a.size for a in ancestors])
-    arrays = np.array([a[:min_len] for a in ancestors])
-    arg_min = np.argmin(arrays[:-1] == arrays[1:], axis=1)
-    val = np.min(arg_min[np.nonzero(arg_min)])
-    return min_len - val
+    ancestor = ancestors[0]
+    ind = 0  # all the ancestors are common up to this index (exclusive).
+    while ind < min_len:
+        if not all([a[ind] == ancestor[ind] for a in ancestors]):
+            break
+        ind += 1
+    return min_len - ind

--- a/tests/utils/data_model_utils/test_structural.py
+++ b/tests/utils/data_model_utils/test_structural.py
@@ -64,6 +64,7 @@ def doc_setup():
                                 </tr>
                             </table>
                         </div>
+                        <p>test8 test9</p>
                     </body>
                 </html>"""
     doc = parser_udf.apply(doc)
@@ -81,6 +82,7 @@ def doc_setup():
         ([4, 5], ["", "html", "body", "div"], 3),
         ([5, 6], ["", "html", "body", "div", "table[2]", "tr"], 1),
         ([3, 5], ["", "html", "body", "div"], 3),
+        ([7, 8], ["", "html", "body", "p"], 0),
     ],
 )
 def test_ancestors(doc_setup, mention_ids, output_common_ancestor, output_lcad):
@@ -100,6 +102,9 @@ def test_ancestors(doc_setup, mention_ids, output_common_ancestor, output_lcad):
     assert mentions[4].sentence.text == "test5"
     assert mentions[5].sentence.text == "test6"
     assert mentions[6].sentence.text == "test7"
+    assert mentions[7].sentence.text == "test8 test9"
+    assert mentions[7].get_span() == "test8"
+    assert mentions[8].get_span() == "test9"
 
     test_mentions = (
         [mentions[i] for i in mention_ids] if len(mention_ids) > 0 else mentions

--- a/tests/utils/data_model_utils/test_structural.py
+++ b/tests/utils/data_model_utils/test_structural.py
@@ -62,7 +62,7 @@ def doc_setup():
                                     <td>test6</td>
                                     <td>test7</td>
                                 </tr>
-                            </table
+                            </table>
                         </div>
                     </body>
                 </html>"""


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

See #486.

**Does your pull request fix any issue.**

Fix #486.

## Description of the proposed changes

Fix `common_ancestor` to return the correct common ancestor for span mentions that share the exact same ancestor.

## Test plan

Add a parameter to `test_ancestors` that demonstrates #486.

## Checklist

* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [ ] I have updated the CHANGELOG.rst accordingly.
