### PR TITLE
Initialize Drawing object every page not to carry over drawings to the following pages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,6 +69,8 @@ Fixed
   (`#477 <https://github.com/HazyResearch/fonduer/pull/477>`_)
 * `@HiromuHota`_: Fix :func:`_get_axis_ngrams` not to return ``None`` when the input is not tabular.
   (`#481 <https://github.com/HazyResearch/fonduer/pull/481>`_)
+* `@HiromuHota`_: Fix :func:`Visualizer.display_candidates` not to draw rectangles on wrong pages.
+  (`#488 <https://github.com/HazyResearch/fonduer/pull/488>`_)
 
 0.8.2_ - 2020-04-28
 -------------------

--- a/src/fonduer/utils/visualizer.py
+++ b/src/fonduer/utils/visualizer.py
@@ -43,7 +43,7 @@ class Visualizer(object):
         imgs = []
         with Color("blue") as blue, Color("red") as red, Color(
             "rgba(0, 0, 0, 0.0)"
-        ) as transparent, Drawing() as draw:
+        ) as transparent:
             colors = [blue, red]
             boxes_per_page: DefaultDict[int, int] = defaultdict(int)
             boxes_by_page: DefaultDict[
@@ -53,13 +53,18 @@ class Visualizer(object):
                 boxes_per_page[page] += 1
                 boxes_by_page[page].append((top, bottom, left, right))
             for i, page_num in enumerate(boxes_per_page.keys()):
-                img = pdf_to_img(pdf_file, page_num)
-                draw.fill_color = transparent
-                for j, (top, bottom, left, right) in enumerate(boxes_by_page[page_num]):
-                    draw.stroke_color = colors[j % 2] if alternate_colors else colors[0]
-                    draw.rectangle(left=left, top=top, right=right, bottom=bottom)
-                draw(img)
-                imgs.append(img)
+                with Drawing() as draw:
+                    img = pdf_to_img(pdf_file, page_num)
+                    draw.fill_color = transparent
+                    for j, (top, bottom, left, right) in enumerate(
+                        boxes_by_page[page_num]
+                    ):
+                        draw.stroke_color = (
+                            colors[j % 2] if alternate_colors else colors[0]
+                        )
+                        draw.rectangle(left=left, top=top, right=right, bottom=bottom)
+                    draw(img)
+                    imgs.append(img)
             return imgs
 
     def display_candidates(


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

### Expected behavior
When displaying candidates like below, the candidates are highlighted by surrounding rectangles.

```python
from hardware_utils import entity_to_candidates
vis = Visualizer(pdf_path)
vis.display_candidates(cands)
```

### Actual behavior
When displaying multiple candidates that span multiple pages, rectangles are drawn not on the right page but also on the following pages.

**Does your pull request fix any issue.**

N/A.

## Description of the proposed changes

Initialize Drawing object every page not to carry over drawings to the following pages

## Test plan

Run the hardware tutorial and see the result manually.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.rst accordingly.
