### PR TITLE
No need to ignore type for torch.__version__ as of PyTorch 1.6.0

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -34,8 +34,6 @@ jobs:
         sudo rm -rf /etc/ImageMagick-6/policy.xml
         sudo apt-get install -q -y poppler-utils
         pip install --upgrade pip setuptools
-        # Install PyTorch for Linux with no CUDA support
-        pip install torch==1.5.0+cpu torchvision==0.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
     - name: Print Version Info
       run: |
         neofetch

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ARG FONDUER_VERSION=
 
 # Install python packages
 RUN pip install \
-    torch==1.4.0+cpu -f https://download.pytorch.org/whl/torch_stable.html \
+    torch==1.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html \
     # https://github.com/HazyResearch/fonduer/issues/390
     "tensorboard<2.0.0,>=1.14.0" "scikit-learn<0.22.0,>=0.20.2" \
     fonduer${FONDUER_VERSION:+==${FONDUER_VERSION}}

--- a/src/fonduer/packaging/fonduer_model.py
+++ b/src/fonduer/packaging/fonduer_model.py
@@ -357,7 +357,7 @@ def _get_default_conda_env() -> Optional[Dict[str, Any]]:
 
     return _mlflow_conda_env(
         additional_conda_deps=[
-            "pytorch={}".format(torch.__version__),  # type: ignore
+            "pytorch={}".format(torch.__version__),
             "psycopg2",
             "pip",
         ],


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

PyTorch 1.6.0 has been released just two days ago.
Mypy complains that "unused 'type: ignore' comment" at `torch.__version__`.
I couldn't track down which change at PyTorch v1.6.0 affects this, but removing that ignore comment satisfies Mypy.

**Does your pull request fix any issue.**

This PR fixes no issue that was reported earlier, but #490 would depend on this.

## Description of the proposed changes

Remove the `# type: ignore` comment to satisfy Mypy.
Also this PR stops explicitly installing PyTorch (no cuda support on Linux). This was intended to speed up the installation time for PyTorch (one that supports cuda is way more bigger in size), but changing the version number every time a newer PyTorch is released turned out to be cumbersome.

## Test plan

Existing tests would be enough.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] I have updated the CHANGELOG.rst accordingly.
