### PR TITLE
Enable RegexMatchSpan with concatenates words by sep="(separator)" option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,9 @@ Added
 
 Changed
 ^^^^^^^
+* `@YasushiMiyata`_: Enable `RegexMatchSpan` with concatenates words by sep="(separator)" option.
+  (`#270 <https://github.com/HazyResearch/fonduer/issues/270>`_)
+  (`#492 <https://github.com/HazyResearch/fonduer/pull/492>`_)
 * `@HiromuHota`_: Enabled "Type hints (PEP 484) support for the Sphinx autodoc extension."
   (`#421 <https://github.com/HazyResearch/fonduer/pull/421>`_)
 * `@HiromuHota`_: Switched the Cython wrapper for Mecab from mecab-python3 to fugashi.

--- a/src/fonduer/candidates/matchers.py
+++ b/src/fonduer/candidates/matchers.py
@@ -294,7 +294,7 @@ class _RegexMatch(_Matcher):
             raise Exception("Please supply a regular expression string r as rgx=r.")
         self.ignore_case = self.opts.get("ignore_case", True)
         self.attrib = self.opts.get("attrib", WORDS)
-        self.sep = self.opts.get("sep", " ")
+        self.sep = self.opts.get("sep", "")
 
         # Extending the _RegexMatch to handle search(instead of only match)
         # and adding a toggle for full span match.

--- a/src/fonduer/candidates/models/implicit_span_mention.py
+++ b/src/fonduer/candidates/models/implicit_span_mention.py
@@ -151,7 +151,7 @@ class TemporaryImplicitSpanMention(TemporarySpanMention):
         """
         return self.__getattribute__(a)
 
-    def get_attrib_span(self, a: str, sep: str = " ") -> str:
+    def get_attrib_span(self, a: str, sep: str = "") -> str:
         """Get the span of sentence attribute *a*.
 
         Intuitively, like calling::
@@ -159,13 +159,14 @@ class TemporaryImplicitSpanMention(TemporarySpanMention):
             sep.join(implicit_span.a)
 
         :param a: The attribute to get a span for.
-        :param sep: The separator to use for the join.
+        :param sep: The separator to use for the join,
+                    or to be removed from text if a="words".
         :return: The joined tokens, or text if a="words".
         """
         if a == "words":
-            return self.text
+            return self.text.replace(sep, "")
         else:
-            return sep.join(self.get_attrib_tokens(a))
+            return sep.join([str(n) for n in self.get_attrib_tokens(a)])
 
     def __getitem__(self, key: slice) -> "TemporaryImplicitSpanMention":
         """Slice operation returns a new candidate sliced according to **char index**.

--- a/src/fonduer/candidates/models/span_mention.py
+++ b/src/fonduer/candidates/models/span_mention.py
@@ -138,7 +138,7 @@ class TemporarySpanMention(TemporaryContext):
             self.get_word_start_index() : self.get_word_end_index() + 1
         ]
 
-    def get_attrib_span(self, a: str, sep: str = " ") -> str:
+    def get_attrib_span(self, a: str, sep: str = "") -> str:
         """Get the span of sentence attribute *a*.
 
         Intuitively, like calling::
@@ -146,15 +146,18 @@ class TemporarySpanMention(TemporaryContext):
             sep.join(span.a)
 
         :param a: The attribute to get a span for.
-        :param sep: The separator to use for the join.
+        :param sep: The separator to use for the join,
+                    or to be removed from text if a="words".
         :return: The joined tokens, or text if a="words".
         """
         # NOTE: Special behavior for words currently (due to correspondence
         # with char_offsets)
         if a == "words":
-            return self.sentence.text[self.char_start : self.char_end + 1]
+            return self.sentence.text[self.char_start : self.char_end + 1].replace(
+                sep, ""
+            )
         else:
-            return sep.join(self.get_attrib_tokens(a))
+            return sep.join([str(n) for n in self.get_attrib_tokens(a)])
 
     def get_span(self) -> str:
         """Return the text of the ``Span``.

--- a/tests/candidates/test_matchers.py
+++ b/tests/candidates/test_matchers.py
@@ -329,6 +329,10 @@ def test_regex_match(doc_setup):
     matcher = RegexMatchEach(rgx=r"Apple", ignore_case=False)
     assert list(matcher.apply(space.apply(doc))) == []
 
+    # Test sep option
+    matcher = RegexMatchSpan(rgx=r"isapple", sep=" ")
+    assert set(tc.get_span() for tc in matcher.apply(space.apply(doc))) == {"is apple"}
+
 
 def test_ner_matchers():
     """Test different ner type matchers."""


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**
A clear and concise description of what the problem is.

A sentence "123 456 789" is parsed and gets three words "123", "456", and "789".
I'd like to match a number like
`RegexMatchSpan(rgx=r"\d{9}", sep=" ")`

but sep=" " has no effect

**Does your pull request fix any issue.**
Fix #270

## Description of the proposed changes
Enable RegexMatchSpan with sep="(separator)" option.
It concatenates mention spans to one word and does RgexMatch without consideration of the separator.

## Test plan
Add Test Code to 'fonduer/tests/candidates/test_matchers.py'.
A sentence "This is apple" is parsed and gets 2 2-grams "This is" and "is apple".
We can get "is apple" with following rgx and sep="(space)" option: 
`RegexMatchSpan(rgx=r"isapple", sep=" ")`

## Checklist

* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.rst accordingly.
