### PR TITLE
Setup/teardown a database every unit test for better isolation

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -52,11 +52,7 @@ jobs:
         make docs
     - name: Set up test databases and test data
       run: |
-        createdb e2e_test -p 5432 -h 127.0.0.1 -w -U postgres
-        createdb inc_test -p 5432 -h 127.0.0.1 -w -U postgres
-        createdb meta_test -p 5432 -h 127.0.0.1 -w -U postgres
-        createdb parser_test -p 5432 -h 127.0.0.1 -w -U postgres
-        createdb pg_test -p 5432 -h 127.0.0.1 -w -U postgres
+        createdb fonduer_test -p 5432 -h 127.0.0.1 -w -U postgres
         cd tests && ./download_data.sh && cd ..
         python -m spacy download en
       env:
@@ -120,11 +116,7 @@ jobs:
         createuser -s postgres
     - name: Set up test databases and test data
       run: |
-        createdb e2e_test -p 5432 -h 127.0.0.1 -w -U postgres
-        createdb inc_test -p 5432 -h 127.0.0.1 -w -U postgres
-        createdb meta_test -p 5432 -h 127.0.0.1 -w -U postgres
-        createdb parser_test -p 5432 -h 127.0.0.1 -w -U postgres
-        createdb pg_test -p 5432 -h 127.0.0.1 -w -U postgres
+        createdb fonduer_test -p 5432 -h 127.0.0.1 -w -U postgres
         cd tests && ./download_data.sh && cd ..
     - name: Print Version Info
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -52,7 +52,6 @@ jobs:
         make docs
     - name: Set up test databases and test data
       run: |
-        createdb fonduer_test -p 5432 -h 127.0.0.1 -w -U postgres
         cd tests && ./download_data.sh && cd ..
         python -m spacy download en
       env:
@@ -116,7 +115,6 @@ jobs:
         createuser -s postgres
     - name: Set up test databases and test data
       run: |
-        createdb fonduer_test -p 5432 -h 127.0.0.1 -w -U postgres
         cd tests && ./download_data.sh && cd ..
     - name: Print Version Info
       run: |

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,4 @@ force_grid_wrap=0
 combine_as_imports=True
 line_length=88
 known_first_party = fonduer,tests
-known_third_party = IPython,bs4,cloudpickle,editdistance,emmental,lxml,mlflow,nltk,numpy,packaging,pandas,pytest,scipy,setuptools,snorkel,spacy,sqlalchemy,tensorboardX,torch,treedlib,wand,yaml
+known_third_party = IPython,bs4,cloudpickle,editdistance,emmental,lxml,mlflow,nltk,numpy,packaging,pandas,psycopg2,pytest,scipy,setuptools,snorkel,spacy,sqlalchemy,tensorboardX,torch,treedlib,wand,yaml

--- a/docs/dev/tests.rst
+++ b/docs/dev/tests.rst
@@ -5,15 +5,7 @@ We use pytest_ to run our tests. Our tests are all located in the ``tests``
 directory in the repo, and are meant to be run *after* installing_ Fonduer
 locally.
 
-In order to run the tests, you will need to create the local databases used
-by the tests::
-
-    $ createdb meta_test
-    $ createdb parser_test
-    $ createdb e2e_test
-    $ createdb inc_test
-    $ createdb pg_test
-
+You need PostgreSQL running locally with `trust authentication`_ enabled.
 You'll also need to download the external test data::
 
     $ cd tests/
@@ -26,3 +18,4 @@ Then, you'll be able to run our tests::
 
 .. _pytest: https://docs.pytest.org/en/latest/
 .. _installing: install.html
+.. _trust authentication: https://www.postgresql.org/docs/current/static/auth-methods.html#AUTH-TRUST

--- a/src/fonduer/meta.py
+++ b/src/fonduer/meta.py
@@ -72,7 +72,6 @@ def new_sessionmaker() -> sessionmaker:
             executemany_mode="batch",
             isolation_level="AUTOCOMMIT",
         )
-        engine.connect()
     except sqlalchemy.exc.OperationalError as e:
         raise ValueError(
             f"{e}\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+import os
+
+import psycopg2
+import pytest
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+from fonduer.meta import Meta
+
+DB = "fonduer_test"
+if "CI" in os.environ:
+    CONN_STRING = (
+        f"postgresql://{os.environ['PGUSER']}:{os.environ['PGPASSWORD']}"
+        + f"@{os.environ['POSTGRES_HOST']}:{os.environ['POSTGRES_PORT']}/{DB}"
+    )
+else:
+    CONN_STRING = f"postgresql://127.0.0.1:5432/{DB}"
+
+
+@pytest.fixture
+def database_session():
+    if "CI" in os.environ:
+        con = psycopg2.connect(
+            host=os.environ["POSTGRES_HOST"],
+            port=os.environ["POSTGRES_PORT"],
+            user=os.environ["PGUSER"],
+            password=os.environ["PGPASSWORD"],
+        )
+    else:
+        con = psycopg2.connect(host="127.0.0.1", port="5432")
+    # Setup
+    con.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    cursor = con.cursor()
+    cursor.execute(f'create database "{DB}";')
+    session = Meta.init(CONN_STRING).Session()
+    yield session
+
+    # Teardown
+    engine = session.get_bind()
+    session.close()
+    engine.dispose()
+    Meta.engine = None
+
+    cursor.execute(f'drop database "{DB}";')
+    cursor.close()
+    con.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,8 @@
+"""conftest.py file that defines shared fixture functions.
+
+See https://docs.pytest.org/en/stable/fixture.html#conftest-py-sharing-fixture-functions
+"""
+
 import os
 
 import psycopg2
@@ -18,6 +23,11 @@ else:
 
 @pytest.fixture
 def database_session():
+    """Fixture function that creates and drops a database.
+
+    As a setup, a database is created and an SQLAlchemy session is passed to a test.
+    As a teardown, the database is dropped after the test runs.
+    """
     if "CI" in os.environ:
         con = psycopg2.connect(
             host=os.environ["POSTGRES_HOST"],

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -60,18 +60,10 @@ from tests.shared.hardware_utils import entity_level_f1, gold
 
 logger = logging.getLogger(__name__)
 ATTRIBUTE = "stg_temp_max"
-DB = "e2e_test"
-if "CI" in os.environ:
-    CONN_STRING = (
-        f"postgresql://{os.environ['PGUSER']}:{os.environ['PGPASSWORD']}"
-        + f"@{os.environ['POSTGRES_HOST']}:{os.environ['POSTGRES_PORT']}/{DB}"
-    )
-else:
-    CONN_STRING = f"postgresql://127.0.0.1:5432/{DB}"
 
 
 @pytest.mark.skipif("CI" not in os.environ, reason="Only run e2e on GitHub Actions")
-def test_e2e():
+def test_e2e(database_session):
     """Run an end-to-end test on documents of the hardware domain."""
     # GitHub Actions gives 2 cores
     # help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
@@ -84,7 +76,7 @@ def test_e2e():
         level=logging.INFO,
     )
 
-    session = fonduer.Meta.init(CONN_STRING).Session()
+    session = database_session
 
     docs_path = "tests/data/html/"
     pdf_path = "tests/data/pdf/"

--- a/tests/e2e/test_incremental.py
+++ b/tests/e2e/test_incremental.py
@@ -5,7 +5,6 @@ import os
 import pytest
 from snorkel.labeling import labeling_function
 
-from fonduer import Meta
 from fonduer.candidates import CandidateExtractor, MentionExtractor
 from fonduer.candidates.models import Candidate
 from fonduer.features import Featurizer
@@ -31,20 +30,12 @@ from tests.shared.hardware_throttlers import temp_throttler
 
 logger = logging.getLogger(__name__)
 ATTRIBUTE = "stg_temp_max"
-DB = "inc_test"
-if "CI" in os.environ:
-    CONN_STRING = (
-        f"postgresql://{os.environ['PGUSER']}:{os.environ['PGPASSWORD']}"
-        + f"@{os.environ['POSTGRES_HOST']}:{os.environ['POSTGRES_PORT']}/{DB}"
-    )
-else:
-    CONN_STRING = f"postgresql://127.0.0.1:5432/{DB}"
 
 
 @pytest.mark.skipif(
     "CI" not in os.environ, reason="Only run incremental on GitHub Actions"
 )
-def test_incremental():
+def test_incremental(database_session):
     """Run an end-to-end test on incremental additions."""
     # GitHub Actions gives 2 cores
     # help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
@@ -52,7 +43,7 @@ def test_incremental():
 
     max_docs = 1
 
-    session = Meta.init(CONN_STRING).Session()
+    session = database_session
 
     docs_path = "tests/data/html/dtc114w.html"
     pdf_path = "tests/data/pdf/dtc114w.pdf"

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -4,7 +4,6 @@ import os
 
 import pytest
 
-import fonduer
 from fonduer.parser import Parser
 from fonduer.parser.lingual_parser import SpacyParser
 from fonduer.parser.models import Document
@@ -15,15 +14,6 @@ from fonduer.parser.preprocessors import (
     TextDocPreprocessor,
     TSVDocPreprocessor,
 )
-
-DB = "parser_test"
-if "CI" in os.environ:
-    CONN_STRING = (
-        f"postgresql://{os.environ['PGUSER']}:{os.environ['PGPASSWORD']}"
-        + f"@{os.environ['POSTGRES_HOST']}:{os.environ['POSTGRES_PORT']}/{DB}"
-    )
-else:
-    CONN_STRING = f"postgresql://127.0.0.1:5432/{DB}"
 
 
 def get_parser_udf(
@@ -825,9 +815,9 @@ def test_parser_no_image():
     assert len(doc.figures) == 0
 
 
-def test_various_file_path_formats():
+def test_various_file_path_formats(database_session):
     """Test the parser with various file path formats."""
-    session = fonduer.Meta.init(CONN_STRING).Session()
+    session = database_session
 
     def parse(docs_path, pdf_path):
         # Preprocessor for the Docs

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,16 +1,20 @@
 """Test Fonduer meta."""
 import logging
+import os
 
+import psycopg2
 import pytest
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+from sqlalchemy.exc import OperationalError
 
 from fonduer import Meta
 from fonduer.candidates.models import mention_subclass
+from tests.conftest import CONN_STRING, DB
 
 logger = logging.getLogger(__name__)
-DB = "meta_test"
 
 
-def test_meta_connection_strings():
+def test_meta_connection_strings(database_session):
     """Simple sanity checks for validating postgres connection strings."""
     with pytest.raises(ValueError):
         Meta.init("postgresql" + DB).Session()
@@ -18,17 +22,43 @@ def test_meta_connection_strings():
     with pytest.raises(ValueError):
         Meta.init("sqlite://somethingsilly" + DB).Session()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(OperationalError):
         Meta.init("postgresql://somethingsilly:5432/").Session()
 
-    Meta.init("postgresql://localhost:5432/" + DB).Session()
+    session = Meta.init("postgresql://localhost:5432/" + DB).Session()
+    engine = session.get_bind()
+    session.close()
+    engine.dispose()
     assert Meta.DBNAME == DB
 
 
 def test_subclass_before_meta_init():
     """Test if mention (candidate) subclass can be created before Meta init."""
+    # Test if mention (candidate) subclass can be created
     Part = mention_subclass("Part")
     logger.info(f"Create a mention subclass '{Part.__tablename__}'")
-    Meta.init("postgresql://localhost:5432/" + DB).Session()
+
+    # Setup a database
+    con = psycopg2.connect(
+        host=os.environ["POSTGRES_HOST"],
+        port=os.environ["POSTGRES_PORT"],
+        user=os.environ["PGUSER"],
+        password=os.environ["PGPASSWORD"],
+    )
+    con.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    cursor = con.cursor()
+    cursor.execute(f'create database "{DB}";')
+    session = Meta.init(CONN_STRING).Session()
+
+    # Test if another mention subclass can be created
     Temp = mention_subclass("Temp")
     logger.info(f"Create a mention subclass '{Temp.__tablename__}'")
+
+    # Teardown the database
+    session.close()
+    Meta.engine.dispose()
+    Meta.engine = None
+
+    cursor.execute(f'drop database "{DB}";')
+    cursor.close()
+    con.close()

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1,8 +1,6 @@
 """Unit tests that involve postgres access."""
 import logging
-import os
 
-from fonduer import Meta
 from fonduer.candidates import CandidateExtractor, MentionExtractor, MentionFigures
 from fonduer.candidates.matchers import LambdaFunctionFigureMatcher
 from fonduer.candidates.models import (
@@ -23,20 +21,12 @@ from tests.shared.hardware_spaces import (
 from tests.shared.hardware_throttlers import temp_throttler
 
 logger = logging.getLogger(__name__)
-DB = "pg_test"
-if "CI" in os.environ:
-    CONN_STRING = (
-        f"postgresql://{os.environ['PGUSER']}:{os.environ['PGPASSWORD']}"
-        + f"@{os.environ['POSTGRES_HOST']}:{os.environ['POSTGRES_PORT']}/{DB}"
-    )
-else:
-    CONN_STRING = f"postgresql://127.0.0.1:5432/{DB}"
 
 
-def test_preprocessor_parse_file_called_once(mocker):
+def test_preprocessor_parse_file_called_once(database_session, mocker):
     """Test if DocPreprocessor._parse_file is called only once during parser.apply."""
     max_docs = 1
-    session = Meta.init(CONN_STRING).Session()
+    session = database_session
     docs_path = "tests/data/html/"
     # Set up preprocessor, parser, and spy on preprocessor
     doc_preprocessor = HTMLDocPreprocessor(docs_path, max_docs=max_docs)
@@ -55,14 +45,14 @@ def test_preprocessor_parse_file_called_once(mocker):
     spy.assert_called_once()
 
 
-def test_cand_gen_cascading_delete():
+def test_cand_gen_cascading_delete(database_session):
     """Test cascading the deletion of candidates."""
     # GitHub Actions gives 2 cores
     # help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
     PARALLEL = 2
 
     max_docs = 1
-    session = Meta.init(CONN_STRING).Session()
+    session = database_session
 
     docs_path = "tests/data/html/"
     pdf_path = "tests/data/pdf/"
@@ -136,7 +126,7 @@ def test_cand_gen_cascading_delete():
     assert session.query(Candidate).count() == 0
 
 
-def test_too_many_clients_error_should_not_happen():
+def test_too_many_clients_error_should_not_happen(database_session):
     """Too many clients error should not happens."""
     PARALLEL = 32
     logger.info("Parallel: {PARALLEL}")
@@ -145,7 +135,7 @@ def test_too_many_clients_error_should_not_happen():
         return True
 
     max_docs = 1
-    session = Meta.init(CONN_STRING).Session()
+    session = database_session
 
     docs_path = "tests/data/html/"
     pdf_path = "tests/data/pdf/"
@@ -200,11 +190,11 @@ def test_too_many_clients_error_should_not_happen():
     candidate_extractor.apply(docs, split=0, parallelism=PARALLEL)
 
 
-def test_parse_error_doc_skipping():
+def test_parse_error_doc_skipping(database_session):
     """Test skipping of faulty htmls."""
     faulty_doc_path = "tests/data/html_faulty/ext_diseases_missing_table_tag.html"
     preprocessor = HTMLDocPreprocessor(faulty_doc_path)
-    session = Meta.init(CONN_STRING).Session()
+    session = database_session
     corpus_parser = Parser(session)
     corpus_parser.apply(preprocessor)
     # This returns documents that apply() was called on


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

This PR makes sure that unit tests are isolated from each other by creating and dropping a database every unit test, which can safety consolidate database names into a single one "fonduer_test".

This isolation is important for Fonduer as it dynamically creates different database tables through `candidate_subclass()` and `mention_subclass()`.
As such, a test for #497 that I will write later would be much helped by this PR.

**Does your pull request fix any issue.**

N/A

## Description of the proposed changes

This PR creates a fixture to setup/teardown a database.

## Test plan

Existing tests would be good enough.

## Checklist

* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] I have updated the CHANGELOG.rst accordingly.
