### PR TITLE
Use "--use-feature=2020-resolver" to fix #390

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ARG FONDUER_VERSION=
 
 # Install python packages
-RUN pip install \
+RUN pip install --upgrade pip
+RUN pip install --use-feature=2020-resolver \
     torch==1.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html \
-    # https://github.com/HazyResearch/fonduer/issues/390
-    "tensorboard<2.0.0,>=1.14.0" "scikit-learn<0.22.0,>=0.20.2" \
     fonduer${FONDUER_VERSION:+==${FONDUER_VERSION}}

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,14 @@
-TESTDATA=tests/input
-
 dev:
 	pip install -r requirements-dev.txt
-	pip install -e .
+	pip install -e . --use-feature=2020-resolver
 	pre-commit install
 
 dev_extra:
 	pip install -r requirements-dev.txt
-	pip install -e .[spacy_ja]
-	pip install -e .[spacy_zh]
+	pip install -e .[spacy_ja,spacy_zh] --use-feature=2020-resolver
 	pre-commit install
 
 test: dev check docs
-	pip install -e .
 	pytest tests
 
 check:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         "beautifulsoup4==4.7.1",
         "editdistance>=0.5.2, <0.6.0",
-        "snorkel>=0.9.5, <0.10.0",  # placed early due to stricter requirements
+        "snorkel>=0.9.5, <0.10.0",
         "emmental>=0.0.6, <0.1.0",
         "lxml>=4.2.5, <5.0.0",
         "mlflow>=1.1.0, <2.0.0",


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

See #390.

**Does your pull request fix any issue.**

Fix #390.

## Description of the proposed changes

Use `--use-feature=2020-resolver` option along with `pip install`.
This option is currently "robust beta" and will become the default resolver as of 20.3, slated to be released on October, 2020 (see [here](https://pip.pypa.io/en/stable/user_guide/#resolver-changes-2020)).
We could wait for 20.3, but I'd like to start testing this.
If something does not work for us, we could report an issue to the pip community before it is released.

## Test plan

Manually check if dependencies are correctly resolved.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] I have updated the CHANGELOG.rst accordingly.
