### PR TITLE
docs: fix epub warning by adding version to conf.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,4 +8,4 @@ count = True
 max-line-length = 88
 statistics = True
 ignore = E731,W503,E741,E203
-exclude = setup.py
+exclude = setup.py, docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@
 import os
 import sys
 
+exec(open("../src/fonduer/_version.py").read())
 sys.path.insert(0, os.path.abspath("../src/"))
 
 autodoc_mock_imports = [
@@ -43,9 +44,9 @@ copyright = "2018, HazyResearch"
 author = "HazyResearch"
 
 # The short X.Y version
-version = ""
+version = __version__.split("+")[0]
 # The full version, including alpha/beta/rc tags
-release = ""
+release = __version__
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
We were previously seeing

```
Running Sphinx v3.2.1
loading translations [en]... done
making output directory... done
WARNING: conf value "version" should not be empty for EPUB3
```

See https://readthedocs.org/projects/fonduer/builds/11957268/