### PR TITLE
Rename "VisualLinker" to "PdfVisualParser" to welcome "HocrVisualParser"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,16 @@ Added
 * `@HiromuHota`_: Support spaCy v2.3.
   (`#506 <https://github.com/HazyResearch/fonduer/pull/506>`_)
 
+Changed
+^^^^^^^
+* `@HiromuHota`_: Renamed :class:`VisualLinker` to :class:`PdfVisualParser`,
+  which takes ``pdf_path``, and changed :class:`Parser`'s signature as follows:
+  (`#518 <https://github.com/HazyResearch/fonduer/pull/518>`_)
+
+    * Renamed ``vizlink`` to ``visual_parser``.
+    * Removed ``pdf_path``. Now this is required only by :class:`PdfVisualLinker`.
+    * Removed ``visual``. Provide ``visual_parser`` if visual information is to be parsed.
+
 0.8.3_ - 2020-09-11
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,14 @@ Added
 Changed
 ^^^^^^^
 * `@HiromuHota`_: Renamed :class:`VisualLinker` to :class:`PdfVisualParser`,
-  which takes ``pdf_path``, and changed :class:`Parser`'s signature as follows:
+  which assumes the followings:
+  (`#518 <https://github.com/HazyResearch/fonduer/pull/518>`_)
+
+    * ``pdf_path`` should be a directory path, where PDF files exist, and cannot be a file path.
+    * The PDF file should have the same basename (:class:`os.path.basename`) as the document.
+      E.g., the PDF file should be either "123.pdf" or "123.PDF" for "123.html".
+
+* `@HiromuHota`_: Changed :class:`Parser`'s signature as follows:
   (`#518 <https://github.com/HazyResearch/fonduer/pull/518>`_)
 
     * Renamed ``vizlink`` to ``visual_parser``.

--- a/docs/user/parser.rst
+++ b/docs/user/parser.rst
@@ -24,11 +24,6 @@ This is Fonduer_'s core Parser object.
     :inherited-members:
     :show-inheritance:
 
-.. automodule:: fonduer.parser.visual_linker
-    :members:
-    :inherited-members:
-    :show-inheritance:
-
 Lingual Parsers
 ---------------
 
@@ -36,6 +31,17 @@ The following docs describe various lingual parsers. They split text into senten
 and enrich them with NLP.
 
 .. automodule:: fonduer.parser.lingual_parser
+    :members:
+    :inherited-members:
+    :show-inheritance:
+
+Visual Parsers
+--------------
+
+The following docs describe various visual parsers. They parse visual information,
+e.g., bounding boxes of each word.
+
+.. automodule:: fonduer.parser.visual_parser
     :members:
     :inherited-members:
     :show-inheritance:

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -62,8 +62,8 @@ class Parser(UDFRunner):
         replaces various unicode variants of a hyphen (e.g. emdash, endash,
         minus, etc.) with a standard ASCII hyphen.
     :param tabular: Whether to include tabular information in the parse.
-    :param visual: Whether to include visual information in the parse.
     :param visual_parser: A visual parser that parses visual information.
+        Defaults to None (visual information is not parsed).
     """
 
     def __init__(
@@ -84,7 +84,6 @@ class Parser(UDFRunner):
             ("[\u2010\u2011\u2012\u2013\u2014\u2212]", "-")
         ],
         tabular: bool = True,  # tabular information
-        visual: bool = False,  # visual information
         visual_parser: Optional[VisualParser] = None,  # visual parser
     ) -> None:
         """Initialize Parser."""
@@ -100,7 +99,6 @@ class Parser(UDFRunner):
             strip=strip,
             replacements=replacements,
             tabular=tabular,
-            visual=visual,
             visual_parser=visual_parser,
             language=language,
         )
@@ -173,14 +171,12 @@ class ParserUDF(UDF):
         strip: bool,
         replacements: List[Tuple[str, str]],
         tabular: bool,
-        visual: bool,
         visual_parser: Optional[VisualParser],
         language: Optional[str],
         **kwargs: Any,
     ) -> None:
         """Initialize Parser UDF.
 
-        :param visual: boolean, if True visual features are used in the model
         :param replacements: a list of (_pattern_, _replace_) tuples where
             _pattern_ isinstance a regex and _replace_ is a character string.
             All occurents of _pattern_ in the text will be replaced by
@@ -221,7 +217,6 @@ class ParserUDF(UDF):
         self.tabular = tabular
 
         # visual setup
-        self.visual = visual
         self.visual_parser = visual_parser
 
     def apply(  # type: ignore
@@ -233,7 +228,7 @@ class ParserUDF(UDF):
         """
         try:
             [y for y in self.parse(document, document.text)]
-            if self.visual and self.visual_parser:
+            if self.visual_parser:
                 if not self.visual_parser.is_parsable(document.name):
                     warnings.warn(
                         (

--- a/src/fonduer/parser/visual_linker.py
+++ b/src/fonduer/parser/visual_linker.py
@@ -37,16 +37,27 @@ HtmlWord = Tuple[HtmlWordId, str]
 
 
 class VisualLinker(object):
-    """Link visual information with sentences."""
+    """Link visual information, extracted from PDF, with parsed sentences.
 
-    def __init__(
-        self, pdf_path: str, time: bool = False, verbose: bool = False
-    ) -> None:
-        """Initialize VisualLinker."""
+    This linker assumes the following conditions for expected results:
+
+    - The PDF file exists in a directory specified by `pdf_path`.
+    - The basename of the PDF file is same as the *document name*
+      and its extension is either ".pdf" or ".PDF".
+    - A PDF has a text layer.
+    """
+
+    def __init__(self, pdf_path: str, verbose: bool = False) -> None:
+        """Initialize VisualLinker.
+
+        :param pdf_path: a path to directory that contains PDF files.
+        :param verbose: whether to turn on verbose logging.
+        """
+        if not os.path.isdir(pdf_path):
+            raise ValueError(f"No directory exists at {pdf_path}!")
         self.pdf_path = pdf_path
         self.pdf_file: Optional[str] = None
         self.verbose = verbose
-        self.time = time
         self.coordinate_map: Optional[Dict[PdfWordId, Bbox]] = None
         self.pdf_word_list: Optional[List[PdfWord]] = None
         self.html_word_list: Optional[List[HtmlWord]] = None
@@ -70,21 +81,16 @@ class VisualLinker(object):
                 f"but should be 0.36.0 or above"
             )
 
-    def link(
-        self, document_name: str, sentences: List[Sentence], pdf_path: str = None
-    ) -> Iterator[Sentence]:
+    def link(self, document_name: str, sentences: List[Sentence]) -> Iterator[Sentence]:
         """Link visual information with sentences.
 
         :param document_name: the document name.
         :param sentences: sentences to be linked with visual information.
-        :param pdf_path: The path to the PDF documents, if any, defaults to None.
-            This path will override the one used in initialization, if provided.
         :return: A generator of ``Sentence``.
         """
         # sentences should be sorted as their order is not deterministic.
         self.sentences = sorted(sentences, key=attrgetter("position"))
-        self.pdf_path = pdf_path if pdf_path is not None else self.pdf_path
-        self.pdf_file = self._get_linked_pdf_path(document_name, self.pdf_path)
+        self.pdf_file = self._get_linked_pdf_path(document_name)
         try:
             self._extract_pdf_words()
         except RuntimeError as e:
@@ -129,36 +135,26 @@ class VisualLinker(object):
         if self.verbose:
             logger.info(f"Extracted {len(self.pdf_word_list)} pdf words")
 
-    def _get_linked_pdf_path(self, filename: str, pdf_path: str = None) -> str:
-        """Get the linked pdf file path, return None if it doesn't exist.
+    def _get_linked_pdf_path(self, document_name: str) -> str:
+        """Get the pdf file path, return None if it doesn't exist.
 
-        :param filename: The name to the PDF document.
-        :param pdf_path: The path to the PDF documents, if any, defaults to None.
+        :param document_name: a document name.
         """
-        path = pdf_path if pdf_path is not None else self.pdf_path
-        # If path is file, but not PDF.
-        if os.path.isfile(path) and path.lower().endswith(".pdf"):
-            return path
-        else:
-            full_path = os.path.join(path, filename)
-            if os.path.isfile(full_path) and full_path.lower().endswith(".pdf"):
-                return full_path
-            full_path = os.path.join(path, filename + ".pdf")
-            if os.path.isfile(full_path):
-                return full_path
-            full_path = os.path.join(path, filename + ".PDF")
-            if os.path.isfile(full_path):
-                return full_path
+        full_path = os.path.join(self.pdf_path, document_name + ".pdf")
+        if os.path.isfile(full_path):
+            return full_path
+        full_path = os.path.join(self.pdf_path, document_name + ".PDF")
+        if os.path.isfile(full_path):
+            return full_path
 
         return None
 
-    def is_linkable(self, filename: str, pdf_path: str = None) -> bool:
+    def is_linkable(self, document_name: str) -> bool:
         """Verify that the file exists and has a PDF extension.
 
-        :param filename: The path to the PDF document.
-        :param pdf_path: The path to the PDF documents, if any, defaults to None.
+        :param document_name: The path to the PDF document.
         """
-        return False if self._get_linked_pdf_path(filename, pdf_path) is None else True
+        return False if self._get_linked_pdf_path(document_name) is None else True
 
     def _coordinates_from_HTML(
         self, page: Tag, page_num: int

--- a/src/fonduer/parser/visual_parser/__init__.py
+++ b/src/fonduer/parser/visual_parser/__init__.py
@@ -1,0 +1,5 @@
+"""Fonduer's visual parser module."""
+from fonduer.parser.visual_parser.pdf_visual_parser import PdfVisualParser
+from fonduer.parser.visual_parser.visual_parser import VisualParser
+
+__all__ = ["VisualParser", "PdfVisualParser"]

--- a/src/fonduer/parser/visual_parser/pdf_visual_parser.py
+++ b/src/fonduer/parser/visual_parser/pdf_visual_parser.py
@@ -1,13 +1,13 @@
-"""Fonduer visual linker."""
+"""Fonduer visual parser."""
 import logging
 import os
 import re
 import shutil
 import subprocess
-from builtins import object, range, zip
+from builtins import range, zip
 from collections import OrderedDict, defaultdict
 from operator import attrgetter
-from typing import DefaultDict, Dict, Iterator, List, Optional, Tuple
+from typing import DefaultDict, Dict, Iterable, Iterator, List, Optional, Tuple
 
 import numpy as np
 from bs4 import BeautifulSoup
@@ -15,6 +15,7 @@ from bs4.element import Tag
 from editdistance import eval as editdist  # Alternative library: python-levenshtein
 
 from fonduer.parser.models import Sentence
+from fonduer.parser.visual_parser.visual_parser import VisualParser
 from fonduer.utils.utils_visual import Bbox
 
 logger = logging.getLogger(__name__)
@@ -36,7 +37,7 @@ HtmlWordId = Tuple[str, int]
 HtmlWord = Tuple[HtmlWordId, str]
 
 
-class VisualLinker(object):
+class PdfVisualParser(VisualParser):
     """Link visual information, extracted from PDF, with parsed sentences.
 
     This linker assumes the following conditions for expected results:
@@ -48,7 +49,7 @@ class VisualLinker(object):
     """
 
     def __init__(self, pdf_path: str, verbose: bool = False) -> None:
-        """Initialize VisualLinker.
+        """Initialize VisualParser.
 
         :param pdf_path: a path to directory that contains PDF files.
         :param verbose: whether to turn on verbose logging.
@@ -81,7 +82,9 @@ class VisualLinker(object):
                 f"but should be 0.36.0 or above"
             )
 
-    def link(self, document_name: str, sentences: List[Sentence]) -> Iterator[Sentence]:
+    def parse(
+        self, document_name: str, sentences: Iterable[Sentence]
+    ) -> Iterator[Sentence]:
         """Link visual information with sentences.
 
         :param document_name: the document name.
@@ -149,7 +152,7 @@ class VisualLinker(object):
 
         return None
 
-    def is_linkable(self, document_name: str) -> bool:
+    def is_parsable(self, document_name: str) -> bool:
         """Verify that the file exists and has a PDF extension.
 
         :param document_name: The path to the PDF document.

--- a/src/fonduer/parser/visual_parser/visual_parser.py
+++ b/src/fonduer/parser/visual_parser/visual_parser.py
@@ -1,0 +1,21 @@
+"""Abstract visual parser."""
+from abc import ABC, abstractmethod
+from typing import Iterable, Iterator
+
+from fonduer.parser.models import Sentence
+
+
+class VisualParser(ABC):
+    """Abstract visual parer."""
+
+    @abstractmethod
+    def parse(
+        self,
+        document_name: str,
+        sentences: Iterable[Sentence],
+    ) -> Iterator[Sentence]:
+        pass
+
+    @abstractmethod
+    def is_parsable(self, document_name: str) -> bool:
+        pass

--- a/src/fonduer/parser/visual_parser/visual_parser.py
+++ b/src/fonduer/parser/visual_parser/visual_parser.py
@@ -14,8 +14,19 @@ class VisualParser(ABC):
         document_name: str,
         sentences: Iterable[Sentence],
     ) -> Iterator[Sentence]:
+        """Parse visual information and link them with given sentences.
+
+        :param document_name: the document name.
+        :param sentences: sentences to be linked with visual information.
+        :yield: sentences with visual information.
+        """
         pass
 
     @abstractmethod
     def is_parsable(self, document_name: str) -> bool:
+        """Check if visual information can be parsed.
+
+        :param document_name: the document name.
+        :return: Whether visual information is parsable.
+        """
         pass

--- a/tests/candidates/test_candidates.py
+++ b/tests/candidates/test_candidates.py
@@ -29,6 +29,7 @@ from fonduer.candidates.mentions import MentionExtractorUDF, Ngrams
 from fonduer.candidates.models import candidate_subclass, mention_subclass
 from fonduer.parser.models import Sentence
 from fonduer.parser.preprocessors import HTMLDocPreprocessor
+from fonduer.parser.visual_linker import VisualLinker
 from fonduer.utils.data_model_utils import get_col_ngrams, get_row_ngrams
 from tests.parser.test_parser import get_parser_udf
 from tests.shared.hardware_matchers import part_matcher, temp_matcher, volt_matcher
@@ -56,7 +57,7 @@ def parse_doc(docs_path: str, file_name: str, pdf_path: Optional[str] = None):
         tabular=True,
         lingual=True,
         visual=True if pdf_path else False,
-        pdf_path=pdf_path,
+        vizlink=VisualLinker(pdf_path) if pdf_path else None,
         language="en",
     )
     doc = parser_udf.apply(doc)
@@ -211,7 +212,7 @@ def test_cand_gen():
         return True
 
     docs_path = "tests/data/html/112823.html"
-    pdf_path = "tests/data/pdf/112823.pdf"
+    pdf_path = "tests/data/pdf/"
     doc = parse_doc(docs_path, "112823", pdf_path)
 
     # Mention Extraction
@@ -546,7 +547,7 @@ def test_pickle_subclasses():
 def test_candidate_with_nullable_mentions():
     """Test if mentions can be NULL."""
     docs_path = "tests/data/html/112823.html"
-    pdf_path = "tests/data/pdf/112823.pdf"
+    pdf_path = "tests/data/pdf/"
     doc = parse_doc(docs_path, "112823", pdf_path)
 
     # Mention Extraction

--- a/tests/candidates/test_candidates.py
+++ b/tests/candidates/test_candidates.py
@@ -29,7 +29,7 @@ from fonduer.candidates.mentions import MentionExtractorUDF, Ngrams
 from fonduer.candidates.models import candidate_subclass, mention_subclass
 from fonduer.parser.models import Sentence
 from fonduer.parser.preprocessors import HTMLDocPreprocessor
-from fonduer.parser.visual_linker import VisualLinker
+from fonduer.parser.visual_parser import PdfVisualParser
 from fonduer.utils.data_model_utils import get_col_ngrams, get_row_ngrams
 from tests.parser.test_parser import get_parser_udf
 from tests.shared.hardware_matchers import part_matcher, temp_matcher, volt_matcher
@@ -57,7 +57,7 @@ def parse_doc(docs_path: str, file_name: str, pdf_path: Optional[str] = None):
         tabular=True,
         lingual=True,
         visual=True if pdf_path else False,
-        vizlink=VisualLinker(pdf_path) if pdf_path else None,
+        visual_parser=PdfVisualParser(pdf_path) if pdf_path else None,
         language="en",
     )
     doc = parser_udf.apply(doc)

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -23,6 +23,7 @@ from fonduer.learning.utils import collect_word_counter
 from fonduer.parser import Parser
 from fonduer.parser.models import Document, Sentence
 from fonduer.parser.preprocessors import HTMLDocPreprocessor
+from fonduer.parser.visual_linker import VisualLinker
 from fonduer.supervision import Labeler
 from fonduer.supervision.models import GoldLabel, Label, LabelKey
 from tests.shared.hardware_lfs import (
@@ -89,7 +90,7 @@ def test_e2e(database_session):
         structural=True,
         lingual=True,
         visual=True,
-        pdf_path=pdf_path,
+        vizlink=VisualLinker(pdf_path),
     )
     corpus_parser.apply(doc_preprocessor)
     assert session.query(Document).count() == max_docs

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -89,7 +89,6 @@ def test_e2e(database_session):
         parallelism=PARALLEL,
         structural=True,
         lingual=True,
-        visual=True,
         visual_parser=PdfVisualParser(pdf_path),
     )
     corpus_parser.apply(doc_preprocessor)

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -23,7 +23,7 @@ from fonduer.learning.utils import collect_word_counter
 from fonduer.parser import Parser
 from fonduer.parser.models import Document, Sentence
 from fonduer.parser.preprocessors import HTMLDocPreprocessor
-from fonduer.parser.visual_linker import VisualLinker
+from fonduer.parser.visual_parser import PdfVisualParser
 from fonduer.supervision import Labeler
 from fonduer.supervision.models import GoldLabel, Label, LabelKey
 from tests.shared.hardware_lfs import (
@@ -90,7 +90,7 @@ def test_e2e(database_session):
         structural=True,
         lingual=True,
         visual=True,
-        vizlink=VisualLinker(pdf_path),
+        visual_parser=PdfVisualParser(pdf_path),
     )
     corpus_parser.apply(doc_preprocessor)
     assert session.query(Document).count() == max_docs

--- a/tests/e2e/test_incremental.py
+++ b/tests/e2e/test_incremental.py
@@ -12,7 +12,7 @@ from fonduer.features.models import Feature, FeatureKey
 from fonduer.parser import Parser
 from fonduer.parser.models import Document
 from fonduer.parser.preprocessors import HTMLDocPreprocessor
-from fonduer.parser.visual_linker import VisualLinker
+from fonduer.parser.visual_parser import PdfVisualParser
 from fonduer.supervision import Labeler
 from fonduer.supervision.labeler import ABSTAIN
 from fonduer.supervision.models import Label, LabelKey
@@ -57,7 +57,7 @@ def test_incremental(database_session):
         structural=True,
         lingual=True,
         visual=True,
-        vizlink=VisualLinker(pdf_path),
+        visual_parser=PdfVisualParser(pdf_path),
     )
     corpus_parser.apply(doc_preprocessor)
 

--- a/tests/e2e/test_incremental.py
+++ b/tests/e2e/test_incremental.py
@@ -56,7 +56,6 @@ def test_incremental(database_session):
         parallelism=PARALLEL,
         structural=True,
         lingual=True,
-        visual=True,
         visual_parser=PdfVisualParser(pdf_path),
     )
     corpus_parser.apply(doc_preprocessor)

--- a/tests/e2e/test_incremental.py
+++ b/tests/e2e/test_incremental.py
@@ -12,6 +12,7 @@ from fonduer.features.models import Feature, FeatureKey
 from fonduer.parser import Parser
 from fonduer.parser.models import Document
 from fonduer.parser.preprocessors import HTMLDocPreprocessor
+from fonduer.parser.visual_linker import VisualLinker
 from fonduer.supervision import Labeler
 from fonduer.supervision.labeler import ABSTAIN
 from fonduer.supervision.models import Label, LabelKey
@@ -46,7 +47,7 @@ def test_incremental(database_session):
     session = database_session
 
     docs_path = "tests/data/html/dtc114w.html"
-    pdf_path = "tests/data/pdf/dtc114w.pdf"
+    pdf_path = "tests/data/pdf/"
 
     doc_preprocessor = HTMLDocPreprocessor(docs_path, max_docs=max_docs)
 
@@ -56,7 +57,7 @@ def test_incremental(database_session):
         structural=True,
         lingual=True,
         visual=True,
-        pdf_path=pdf_path,
+        vizlink=VisualLinker(pdf_path),
     )
     corpus_parser.apply(doc_preprocessor)
 
@@ -140,11 +141,11 @@ def test_incremental(database_session):
     assert len(labeler.get_keys()) == 5
 
     docs_path = "tests/data/html/112823.html"
-    pdf_path = "tests/data/pdf/112823.pdf"
+    pdf_path = "tests/data/pdf/"
 
     doc_preprocessor = HTMLDocPreprocessor(docs_path, max_docs=max_docs)
 
-    corpus_parser.apply(doc_preprocessor, pdf_path=pdf_path, clear=False)
+    corpus_parser.apply(doc_preprocessor, clear=False)
 
     assert len(corpus_parser.get_documents()) == 2
 

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 def test_unary_relation_feature_extraction():
     """Test extracting unary candidates from mentions from documents."""
     docs_path = "tests/data/html/112823.html"
-    pdf_path = "tests/data/pdf/112823.pdf"
+    pdf_path = "tests/data/pdf/"
 
     # Parsing
     doc = parse_doc(docs_path, "112823", pdf_path)
@@ -105,7 +105,7 @@ def test_unary_relation_feature_extraction():
 def test_binary_relation_feature_extraction():
     """Test extracting candidates from mentions from documents."""
     docs_path = "tests/data/html/112823.html"
-    pdf_path = "tests/data/pdf/112823.pdf"
+    pdf_path = "tests/data/pdf/"
 
     # Parsing
     doc = parse_doc(docs_path, "112823", pdf_path)
@@ -239,7 +239,7 @@ def test_binary_relation_feature_extraction():
 def test_multinary_relation_feature_extraction():
     """Test extracting candidates from mentions from documents."""
     docs_path = "tests/data/html/112823.html"
-    pdf_path = "tests/data/pdf/112823.pdf"
+    pdf_path = "tests/data/pdf/"
 
     # Parsing
     doc = parse_doc(docs_path, "112823", pdf_path)

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -850,7 +850,6 @@ def test_various_file_path_formats(database_session):
             parallelism=1,
             structural=True,
             lingual=True,
-            visual=True,
             visual_parser=PdfVisualParser(pdf_path),
         )
 

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -7,7 +7,7 @@ import pytest
 from fonduer.parser import Parser
 from fonduer.parser.lingual_parser import SpacyParser
 from fonduer.parser.models import Document
-from fonduer.parser.parser import ParserUDF, SimpleParser
+from fonduer.parser.parser import ParserUDF, SimpleParser, VisualLinker
 from fonduer.parser.preprocessors import (
     CSVDocPreprocessor,
     HTMLDocPreprocessor,
@@ -28,7 +28,6 @@ def get_parser_udf(
     tabular=True,  # tabular information
     visual=False,  # visual information
     vizlink=None,
-    pdf_path=None,
 ):
     """Return an instance of ParserUDF."""
     parser_udf = ParserUDF(
@@ -42,7 +41,6 @@ def get_parser_udf(
         tabular=tabular,
         visual=visual,
         vizlink=vizlink,
-        pdf_path=pdf_path,
         language=language,
     )
     return parser_udf
@@ -53,7 +51,7 @@ def test_parse_md_details():
     logger = logging.getLogger(__name__)
 
     docs_path = "tests/data/html_simple/md.html"
-    pdf_path = "tests/data/pdf_simple/md.pdf"
+    pdf_path = "tests/data/pdf_simple/"
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
@@ -74,7 +72,7 @@ def test_parse_md_details():
         tabular=True,
         lingual=True,
         visual=True,
-        pdf_path=pdf_path,
+        vizlink=VisualLinker(pdf_path),
         language="en",
     )
     doc = parser_udf.apply(doc)
@@ -155,7 +153,7 @@ def test_parse_md_details():
 def test_parse_wo_tabular():
     """Test the parser without extracting tabular information."""
     docs_path = "tests/data/html_simple/md.html"
-    pdf_path = "tests/data/pdf_simple/md.pdf"
+    pdf_path = "tests/data/pdf_simple/"
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
@@ -167,7 +165,7 @@ def test_parse_wo_tabular():
         tabular=False,
         lingual=True,
         visual=True,
-        pdf_path=pdf_path,
+        vizlink=VisualLinker(pdf_path),
         language="en",
     )
     doc = parser_udf.apply(doc)
@@ -340,7 +338,7 @@ def test_warning_on_missing_pdf():
 def test_warning_on_incorrect_filename():
     """Test that a warning is issued on invalid pdf."""
     docs_path = "tests/data/html_simple/md_para.html"
-    pdf_path = "tests/data/html_simple/md_para.html"
+    pdf_path = "tests/data/html_simple/"
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
@@ -348,7 +346,11 @@ def test_warning_on_incorrect_filename():
 
     # Create an Parser and parse the md document
     parser_udf = get_parser_udf(
-        structural=True, tabular=True, lingual=True, visual=True, pdf_path=pdf_path
+        structural=True,
+        tabular=True,
+        lingual=True,
+        visual=True,
+        vizlink=VisualLinker(pdf_path),
     )
     with pytest.warns(RuntimeWarning) as record:
         doc = parser_udf.apply(doc)
@@ -359,7 +361,7 @@ def test_warning_on_incorrect_filename():
 def test_parse_md_paragraphs():
     """Unit test of Paragraph parsing."""
     docs_path = "tests/data/html_simple/md_para.html"
-    pdf_path = "tests/data/pdf_simple/md_para.pdf"
+    pdf_path = "tests/data/pdf_simple/"
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
@@ -370,7 +372,11 @@ def test_parse_md_paragraphs():
 
     # Create an Parser and parse the md document
     parser_udf = get_parser_udf(
-        structural=True, tabular=True, lingual=True, visual=True, pdf_path=pdf_path
+        structural=True,
+        tabular=True,
+        lingual=True,
+        visual=True,
+        vizlink=VisualLinker(pdf_path),
     )
     doc = parser_udf.apply(doc)
 
@@ -445,7 +451,7 @@ def test_simple_parser():
     logger = logging.getLogger(__name__)
 
     docs_path = "tests/data/html_simple/md.html"
-    pdf_path = "tests/data/pdf_simple/md.pdf"
+    pdf_path = "tests/data/pdf_simple/"
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
@@ -459,7 +465,7 @@ def test_simple_parser():
         structural=True,
         lingual=False,
         visual=True,
-        pdf_path=pdf_path,
+        vizlink=VisualLinker(pdf_path),
         lingual_parser=SimpleParser(delim="NoDelim"),
     )
     doc = parser_udf.apply(doc)
@@ -527,7 +533,7 @@ def test_parse_document_diseases():
     logger = logging.getLogger(__name__)
 
     docs_path = "tests/data/html_simple/diseases.html"
-    pdf_path = "tests/data/pdf_simple/diseases.pdf"
+    pdf_path = "tests/data/pdf_simple/"
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
@@ -538,7 +544,10 @@ def test_parse_document_diseases():
 
     # Create an Parser and parse the diseases document
     parser_udf = get_parser_udf(
-        structural=True, lingual=True, visual=True, pdf_path=pdf_path
+        structural=True,
+        lingual=True,
+        visual=True,
+        vizlink=VisualLinker(pdf_path),
     )
     doc = parser_udf.apply(doc)
 
@@ -597,7 +606,7 @@ def test_parse_style():
     logger = logging.getLogger(__name__)
 
     docs_path = "tests/data/html_extended/ext_diseases.html"
-    pdf_path = "tests/data/pdf_extended/ext_diseases.pdf"
+    pdf_path = "tests/data/pdf_extended/"
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
@@ -605,7 +614,10 @@ def test_parse_style():
 
     # Create an Parser and parse the diseases document
     parser_udf = get_parser_udf(
-        structural=True, lingual=True, visual=True, pdf_path=pdf_path
+        structural=True,
+        lingual=True,
+        visual=True,
+        vizlink=VisualLinker(pdf_path),
     )
     doc = parser_udf.apply(doc)
 
@@ -797,7 +809,7 @@ def test_parser_skips_and_flattens():
 def test_parser_no_image():
     """Unit test of Parser on a single document that has a figure without image."""
     docs_path = "tests/data/html_simple/no_image.html"
-    pdf_path = "tests/data/pdf_simple/no_image.pdf"
+    pdf_path = "tests/data/pdf_simple/"
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
@@ -811,7 +823,7 @@ def test_parser_no_image():
         structural=True,
         lingual=False,
         visual=True,
-        pdf_path=pdf_path,
+        vizlink=VisualLinker(pdf_path),
     )
     doc = parser_udf.apply(doc)
 
@@ -834,7 +846,7 @@ def test_various_file_path_formats(database_session):
             structural=True,
             lingual=True,
             visual=True,
-            pdf_path=pdf_path,
+            vizlink=VisualLinker(pdf_path),
         )
 
         corpus_parser.clear()
@@ -843,7 +855,7 @@ def test_various_file_path_formats(database_session):
 
     # Test that doc_path is a file path, and pdf_path is a file path
     docs_path = "tests/data/html_simple/md.html"
-    pdf_path = "tests/data/pdf_simple/md.pdf"
+    pdf_path = "tests/data/pdf_simple/"
 
     corpus_parser = parse(docs_path, pdf_path)
     docs = corpus_parser.get_documents()

--- a/tests/parser/test_visual_linker.py
+++ b/tests/parser/test_visual_linker.py
@@ -1,4 +1,4 @@
-"""Fonduer visual_linker unit tests."""
+"""Fonduer visual_parser unit tests."""
 import random
 from operator import attrgetter
 
@@ -6,35 +6,35 @@ import pytest
 from bs4 import BeautifulSoup
 
 from fonduer.parser.preprocessors import HTMLDocPreprocessor
-from fonduer.parser.visual_linker import VisualLinker
+from fonduer.parser.visual_parser import PdfVisualParser
 from tests.parser.test_parser import get_parser_udf
 
 
-def test_visual_linker_not_affected_by_order_of_sentences():
-    """Test if visual_linker result is not affected by the order of sentences."""
+def test_visual_parser_not_affected_by_order_of_sentences():
+    """Test if visual_parser result is not affected by the order of sentences."""
     docs_path = "tests/data/html/2N6427.html"
     pdf_path = "tests/data/pdf/"
 
-    # Initialize preprocessor, parser, visual_linker.
-    # Note that parser is initialized with `visual=False` and that visual_linker
+    # Initialize preprocessor, parser, visual_parser.
+    # Note that parser is initialized with `visual=False` and that visual_parser
     # will be used to attach "visual" information to sentences after parsing.
     preprocessor = HTMLDocPreprocessor(docs_path)
     parser_udf = get_parser_udf(
         structural=True, lingual=False, tabular=True, visual=False
     )
-    visual_linker = VisualLinker(pdf_path=pdf_path)
+    visual_parser = PdfVisualParser(pdf_path=pdf_path)
 
     doc = parser_udf.apply(next(preprocessor.__iter__()))
     # Sort sentences by sentence.position
     doc.sentences = sorted(doc.sentences, key=attrgetter("position"))
-    sentences0 = [sent for sent in visual_linker.link(doc.name, doc.sentences)]
-    # Sort again in case visual_linker.link changes the order
+    sentences0 = [sent for sent in visual_parser.parse(doc.name, doc.sentences)]
+    # Sort again in case visual_parser.link changes the order
     sentences0 = sorted(sentences0, key=attrgetter("position"))
 
     doc = parser_udf.apply(next(preprocessor.__iter__()))
     # Shuffle
     random.shuffle(doc.sentences)
-    sentences1 = [sent for sent in visual_linker.link(doc.name, doc.sentences)]
+    sentences1 = [sent for sent in visual_parser.parse(doc.name, doc.sentences)]
     # Sort sentences by sentence.position
     sentences1 = sorted(sentences1, key=attrgetter("position"))
 
@@ -46,7 +46,7 @@ def test_visual_linker_not_affected_by_order_of_sentences():
         ]
     )
 
-    # The following assertion should hold if the visual_linker result is not affected
+    # The following assertion should hold if the visual_parser result is not affected
     # by the order of sentences.
     assert all(
         [sent0.left == sent1.left for (sent0, sent1) in zip(sentences0, sentences1)]
@@ -57,7 +57,7 @@ def test_non_existent_pdf_path_should_fail():
     """Test if a non-existent raises an error."""
     pdf_path = "dummy_path"
     with pytest.raises(ValueError):
-        VisualLinker(pdf_path=pdf_path)
+        PdfVisualParser(pdf_path=pdf_path)
 
 
 def test_pdf_word_list_is_sorted():
@@ -69,11 +69,11 @@ def test_pdf_word_list_is_sorted():
     """
     docs_path = "tests/data/html_simple/no_image_unsorted.html"
     pdf_path = "tests/data/pdf_simple"
-    visual_linker = VisualLinker(pdf_path=pdf_path)
+    visual_parser = PdfVisualParser(pdf_path=pdf_path)
     with open(docs_path) as f:
         soup = BeautifulSoup(f, "html.parser")
     page = soup.find_all("page")[0]
-    pdf_word_list, coordinate_map = visual_linker._coordinates_from_HTML(page, 1)
+    pdf_word_list, coordinate_map = visual_parser._coordinates_from_HTML(page, 1)
 
     # Check if words are sorted by block top
     assert set([content for (_, content) in pdf_word_list[:2]]) == {"Sample", "HTML"}

--- a/tests/parser/test_visual_linker.py
+++ b/tests/parser/test_visual_linker.py
@@ -2,6 +2,7 @@
 import random
 from operator import attrgetter
 
+import pytest
 from bs4 import BeautifulSoup
 
 from fonduer.parser.preprocessors import HTMLDocPreprocessor
@@ -12,7 +13,7 @@ from tests.parser.test_parser import get_parser_udf
 def test_visual_linker_not_affected_by_order_of_sentences():
     """Test if visual_linker result is not affected by the order of sentences."""
     docs_path = "tests/data/html/2N6427.html"
-    pdf_path = "tests/data/pdf/2N6427.pdf"
+    pdf_path = "tests/data/pdf/"
 
     # Initialize preprocessor, parser, visual_linker.
     # Note that parser is initialized with `visual=False` and that visual_linker
@@ -26,18 +27,14 @@ def test_visual_linker_not_affected_by_order_of_sentences():
     doc = parser_udf.apply(next(preprocessor.__iter__()))
     # Sort sentences by sentence.position
     doc.sentences = sorted(doc.sentences, key=attrgetter("position"))
-    sentences0 = [
-        sent for sent in visual_linker.link(doc.name, doc.sentences, pdf_path)
-    ]
+    sentences0 = [sent for sent in visual_linker.link(doc.name, doc.sentences)]
     # Sort again in case visual_linker.link changes the order
     sentences0 = sorted(sentences0, key=attrgetter("position"))
 
     doc = parser_udf.apply(next(preprocessor.__iter__()))
     # Shuffle
     random.shuffle(doc.sentences)
-    sentences1 = [
-        sent for sent in visual_linker.link(doc.name, doc.sentences, pdf_path)
-    ]
+    sentences1 = [sent for sent in visual_linker.link(doc.name, doc.sentences)]
     # Sort sentences by sentence.position
     sentences1 = sorted(sentences1, key=attrgetter("position"))
 
@@ -56,6 +53,13 @@ def test_visual_linker_not_affected_by_order_of_sentences():
     )
 
 
+def test_non_existent_pdf_path_should_fail():
+    """Test if a non-existent raises an error."""
+    pdf_path = "dummy_path"
+    with pytest.raises(ValueError):
+        VisualLinker(pdf_path=pdf_path)
+
+
 def test_pdf_word_list_is_sorted():
     """Test if pdf_word_list is sorted as expected.
 
@@ -64,7 +68,7 @@ def test_pdf_word_list_is_sorted():
     pdf_word_list is sorted as expected.
     """
     docs_path = "tests/data/html_simple/no_image_unsorted.html"
-    pdf_path = "dummy_path"
+    pdf_path = "tests/data/pdf_simple"
     visual_linker = VisualLinker(pdf_path=pdf_path)
     with open(docs_path) as f:
         soup = BeautifulSoup(f, "html.parser")

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -12,7 +12,7 @@ from fonduer.candidates.models import (
 from fonduer.parser import Parser
 from fonduer.parser.models import Document, Sentence
 from fonduer.parser.preprocessors import HTMLDocPreprocessor
-from fonduer.parser.visual_linker import VisualLinker
+from fonduer.parser.visual_parser import PdfVisualParser
 from tests.shared.hardware_matchers import part_matcher, temp_matcher, volt_matcher
 from tests.shared.hardware_spaces import (
     MentionNgramsPart,
@@ -66,7 +66,7 @@ def test_cand_gen_cascading_delete(database_session):
         structural=True,
         lingual=True,
         visual=True,
-        vizlink=VisualLinker(pdf_path),
+        visual_parser=PdfVisualParser(pdf_path),
     )
     corpus_parser.apply(doc_preprocessor, parallelism=PARALLEL)
     assert session.query(Document).count() == max_docs
@@ -153,7 +153,7 @@ def test_too_many_clients_error_should_not_happen(database_session):
         structural=True,
         lingual=True,
         visual=True,
-        vizlink=VisualLinker(pdf_path),
+        visual_parser=PdfVisualParser(pdf_path),
     )
     corpus_parser.apply(doc_preprocessor, parallelism=PARALLEL)
     docs = session.query(Document).order_by(Document.name).all()

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -12,6 +12,7 @@ from fonduer.candidates.models import (
 from fonduer.parser import Parser
 from fonduer.parser.models import Document, Sentence
 from fonduer.parser.preprocessors import HTMLDocPreprocessor
+from fonduer.parser.visual_linker import VisualLinker
 from tests.shared.hardware_matchers import part_matcher, temp_matcher, volt_matcher
 from tests.shared.hardware_spaces import (
     MentionNgramsPart,
@@ -61,7 +62,11 @@ def test_cand_gen_cascading_delete(database_session):
     logger.info("Parsing...")
     doc_preprocessor = HTMLDocPreprocessor(docs_path, max_docs=max_docs)
     corpus_parser = Parser(
-        session, structural=True, lingual=True, visual=True, pdf_path=pdf_path
+        session,
+        structural=True,
+        lingual=True,
+        visual=True,
+        vizlink=VisualLinker(pdf_path),
     )
     corpus_parser.apply(doc_preprocessor, parallelism=PARALLEL)
     assert session.query(Document).count() == max_docs
@@ -144,7 +149,11 @@ def test_too_many_clients_error_should_not_happen(database_session):
     logger.info("Parsing...")
     doc_preprocessor = HTMLDocPreprocessor(docs_path, max_docs=max_docs)
     corpus_parser = Parser(
-        session, structural=True, lingual=True, visual=True, pdf_path=pdf_path
+        session,
+        structural=True,
+        lingual=True,
+        visual=True,
+        vizlink=VisualLinker(pdf_path),
     )
     corpus_parser.apply(doc_preprocessor, parallelism=PARALLEL)
     docs = session.query(Document).order_by(Document.name).all()

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -65,7 +65,6 @@ def test_cand_gen_cascading_delete(database_session):
         session,
         structural=True,
         lingual=True,
-        visual=True,
         visual_parser=PdfVisualParser(pdf_path),
     )
     corpus_parser.apply(doc_preprocessor, parallelism=PARALLEL)
@@ -152,7 +151,6 @@ def test_too_many_clients_error_should_not_happen(database_session):
         session,
         structural=True,
         lingual=True,
-        visual=True,
         visual_parser=PdfVisualParser(pdf_path),
     )
     corpus_parser.apply(doc_preprocessor, parallelism=PARALLEL)

--- a/tests/utils/data_model_utils/test_structural.py
+++ b/tests/utils/data_model_utils/test_structural.py
@@ -18,7 +18,7 @@ def get_parser_udf(
     replacements=[("[\u2010\u2011\u2012\u2013\u2014\u2212]", "-")],
     tabular=True,  # tabular information
     visual=False,  # visual information
-    vizlink=None,
+    visual_parser=None,
     pdf_path=None,
 ):
     """Return an instance of ParserUDF."""
@@ -32,7 +32,7 @@ def get_parser_udf(
         replacements=replacements,
         tabular=tabular,
         visual=visual,
-        vizlink=vizlink,
+        visual_parser=visual_parser,
         pdf_path=pdf_path,
         language=language,
     )

--- a/tests/utils/data_model_utils/test_tabular.py
+++ b/tests/utils/data_model_utils/test_tabular.py
@@ -3,6 +3,7 @@ import pytest
 
 from fonduer.candidates import MentionNgrams
 from fonduer.parser.preprocessors import HTMLDocPreprocessor
+from fonduer.parser.visual_linker import VisualLinker
 from fonduer.utils.data_model_utils.tabular import (
     get_aligned_ngrams,
     get_cell_ngrams,
@@ -29,7 +30,7 @@ from tests.parser.test_parser import get_parser_udf
 def mention_setup():
     """Set up mentions."""
     docs_path = "tests/data/html_simple/md.html"
-    pdf_path = "tests/data/pdf_simple/md.pdf"
+    pdf_path = "tests/data/pdf_simple/"
 
     # Preprocessor for the Docs
     preprocessor = HTMLDocPreprocessor(docs_path)
@@ -41,7 +42,7 @@ def mention_setup():
         tabular=True,
         lingual=True,
         visual=True,
-        pdf_path=pdf_path,
+        vizlink=VisualLinker(pdf_path),
         language="en",
     )
     doc = parser_udf.apply(doc)

--- a/tests/utils/data_model_utils/test_tabular.py
+++ b/tests/utils/data_model_utils/test_tabular.py
@@ -3,7 +3,7 @@ import pytest
 
 from fonduer.candidates import MentionNgrams
 from fonduer.parser.preprocessors import HTMLDocPreprocessor
-from fonduer.parser.visual_linker import VisualLinker
+from fonduer.parser.visual_parser import PdfVisualParser
 from fonduer.utils.data_model_utils.tabular import (
     get_aligned_ngrams,
     get_cell_ngrams,
@@ -42,7 +42,7 @@ def mention_setup():
         tabular=True,
         lingual=True,
         visual=True,
-        vizlink=VisualLinker(pdf_path),
+        visual_parser=PdfVisualParser(pdf_path),
         language="en",
     )
     doc = parser_udf.apply(doc)

--- a/tests/utils/test_visualizer.py
+++ b/tests/utils/test_visualizer.py
@@ -12,7 +12,7 @@ def test_visualizer():
     from fonduer.utils.visualizer import Visualizer, get_box  # noqa
 
     docs_path = "tests/data/html_simple/md.html"
-    pdf_path = "tests/data/pdf_simple/md.pdf"
+    pdf_path = "tests/data/pdf_simple/"
 
     # Grab the md document
     doc = parse_doc(docs_path, "md", pdf_path)


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

As #509 now became a big PR, I'll break it down into smaller PRs.
To support hOCR (#476), this PR renames `VisualLinker` to `PdfVisualParser` to welcome `HocrVisualParser`, which will be submitted in a separate PR.

**Does your pull request fix any issue.**

N/A.

## Description of the proposed changes

- Renamed `VisualLinker` to `PdfVisualParser`, which takes `pdf_path` as an argument
    - `pdf_path` now should be a path to a directory containing PDF files.
    - The PDF file's name should be the same as *document_name* + ".pdf" (or ".PDF")
- Changed `Parser`'s signature:
    - Renamed `vizlink` to `visual_parser`.
    - Removed `pdf_path`. Now this is required only by `PdfVisualParser`.
    - Removed `visual`. Use `visual_parser` if visual information is to be parsed.

## Test plan
A clear and concise description of how you test the new changes.

## Checklist

* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.rst accordingly.
