### PR TITLE
Unwrap "ocrx_line" as well as "ocr_line" as Fonduer has no data model 

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 black>=18.9b0
 flake8>=3.8.0
 flake8-docstrings
-mypy
+mypy==0.782
 nltk
 isort>=5.0.0
 pre-commit

--- a/src/fonduer/parser/preprocessors/hocr_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/hocr_doc_preprocessor.py
@@ -72,16 +72,20 @@ class HOCRDocPreprocessor(DocPreprocessor):
             )
         root = all_html_elements[0]
         capabilities = root.find("meta", attrs={"name": "ocr-capabilities"})
+        if capabilities is None:
+            raise RuntimeError(
+                "The input hOCR does not contain ocr-capabilities metadata."
+            )
 
         # Unwrap ocr_line/ocrx_line as Fonduer has no data model for lines.
-        if capabilities and "ocr_line" in capabilities["content"]:
+        if "ocr_line" in capabilities["content"]:
             for line in root.find_all(class_="ocr_line"):
                 line.unwrap()
-        elif capabilities and "ocrx_line" in capabilities["content"]:
+        if "ocrx_line" in capabilities["content"]:
             for line in root.find_all(class_="ocrx_line"):
                 line.unwrap()
 
-        if capabilities and "ocrx_word" in capabilities["content"]:
+        if "ocrx_word" in capabilities["content"]:
             for p, page in enumerate(root.find_all(class_="ocr_page")):
                 ppageno = str(p)  # 0-based
                 for word in page.find_all(class_="ocrx_word"):

--- a/src/fonduer/parser/preprocessors/hocr_doc_preprocessor.py
+++ b/src/fonduer/parser/preprocessors/hocr_doc_preprocessor.py
@@ -72,9 +72,15 @@ class HOCRDocPreprocessor(DocPreprocessor):
             )
         root = all_html_elements[0]
         capabilities = root.find("meta", attrs={"name": "ocr-capabilities"})
+
+        # Unwrap ocr_line/ocrx_line as Fonduer has no data model for lines.
         if capabilities and "ocr_line" in capabilities["content"]:
             for line in root.find_all(class_="ocr_line"):
                 line.unwrap()
+        elif capabilities and "ocrx_line" in capabilities["content"]:
+            for line in root.find_all(class_="ocrx_line"):
+                line.unwrap()
+
         if capabilities and "ocrx_word" in capabilities["content"]:
             for p, page in enumerate(root.find_all(class_="ocr_page")):
                 ppageno = str(p)  # 0-based

--- a/tests/data/hocr_simple/md.hocr
+++ b/tests/data/hocr_simple/md.hocr
@@ -1,297 +1,201 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
- <head>
-  <title></title>
-  <meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
-  <meta name='ocr-system' content='tesseract 4.1.1' />
-  <meta name='ocr-capabilities' content='ocr_page ocr_carea ocr_par ocr_line ocrx_word ocrp_wconf'/>
- </head>
- <body>
-  <div class='ocr_page' id='page_1' title='image "md.pbm-1.pgm"; bbox 0 0 2550 3301; ppageno 0'>
-   <div class='ocr_carea' id='block_1_1' title="bbox 150 166 963 257">
-    <p class='ocr_par' id='par_1_1' lang='eng' title="bbox 150 166 963 257">
-     <span class='ocr_line' id='line_1_1' title="bbox 150 166 963 257; baseline -0.001 -20; x_size 91; x_descenders 20; x_ascenders 23">
-      <span class='ocrx_word' id='word_1_1' title='bbox 150 166 460 257; x_wconf 95'>Sample</span>
-      <span class='ocrx_word' id='word_1_2' title='bbox 489 166 963 237; x_wconf 95'>Markdown</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_2' title="bbox 146 335 915 381">
-    <p class='ocr_par' id='par_1_2' lang='eng' title="bbox 146 335 915 381">
-     <span class='ocr_line' id='line_1_2' title="bbox 146 335 915 381; baseline 0.001 -11; x_size 46; x_descenders 10; x_ascenders 11">
-      <span class='ocrx_word' id='word_1_3' title='bbox 146 335 233 371; x_wconf 96'>This</span>
-      <span class='ocrx_word' id='word_1_4' title='bbox 248 337 279 371; x_wconf 96'>is</span>
-      <span class='ocrx_word' id='word_1_5' title='bbox 295 346 397 371; x_wconf 96'>some</span>
-      <span class='ocrx_word' id='word_1_6' title='bbox 411 335 522 378; x_wconf 96'>basic,</span>
-      <span class='ocrx_word' id='word_1_7' title='bbox 540 335 679 381; x_wconf 93'>sample</span>
-      <span class='ocrx_word' id='word_1_8' title='bbox 693 335 915 371; x_wconf 93'>markdown.</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_3' title="bbox 149 459 664 528">
-    <p class='ocr_par' id='par_1_3' lang='eng' title="bbox 149 459 664 528">
-     <span class='ocr_line' id='line_1_3' title="bbox 149 459 664 528; baseline -0.002 -16; x_size 70; x_descenders 17; x_ascenders 17">
-      <span class='ocrx_word' id='word_1_9' title='bbox 149 459 374 512; x_wconf 96'>Second</span>
-      <span class='ocrx_word' id='word_1_10' title='bbox 394 459 664 528; x_wconf 96'>Heading</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_4' title="bbox 221 601 684 644">
-    <p class='ocr_par' id='par_1_4' lang='eng' title="bbox 221 601 684 644">
-     <span class='ocr_line' id='line_1_4' title="bbox 221 601 684 644; baseline 0.002 -8; x_size 43; x_descenders 7; x_ascenders 11">
-      <span class='ocrx_word' id='word_1_11' title='bbox 221 615 236 630; x_wconf 89'>=</span>
-      <span class='ocrx_word' id='word_1_12' title='bbox 271 601 484 637; x_wconf 92'>Unordered</span>
-      <span class='ocrx_word' id='word_1_13' title='bbox 498 601 586 644; x_wconf 96'>lists,</span>
-      <span class='ocrx_word' id='word_1_14' title='bbox 604 601 684 637; x_wconf 96'>and:</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_5' title="bbox 349 659 477 693">
-    <p class='ocr_par' id='par_1_5' lang='eng' title="bbox 349 659 477 693">
-     <span class='ocr_line' id='line_1_5' title="bbox 349 659 477 693; baseline 0.008 -1; x_size 39.392159; x_descenders 5.3921571; x_ascenders 9">
-      <span class='ocrx_word' id='word_1_15' title='bbox 349 659 379 693; x_wconf 96'>1.</span>
-      <span class='ocrx_word' id='word_1_16' title='bbox 397 659 477 693; x_wconf 96'>One</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_6' title="bbox 347 715 481 749">
-    <p class='ocr_par' id='par_1_6' lang='eng' title="bbox 347 715 481 749">
-     <span class='ocr_line' id='line_1_6' title="bbox 347 715 481 749; baseline 0.007 -1; x_size 39.76923; x_descenders 5.7692308; x_ascenders 9">
-      <span class='ocrx_word' id='word_1_17' title='bbox 347 715 379 749; x_wconf 95'>2.</span>
-      <span class='ocrx_word' id='word_1_18' title='bbox 396 715 481 749; x_wconf 94'>Two</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_7' title="bbox 347 770 511 806">
-    <p class='ocr_par' id='par_1_7' lang='eng' title="bbox 347 770 511 806">
-     <span class='ocr_line' id='line_1_7' title="bbox 347 770 511 806; baseline 0 0; x_size 41.392159; x_descenders 5.3921571; x_ascenders 11">
-      <span class='ocrx_word' id='word_1_19' title='bbox 347 772 379 806; x_wconf 96'>3.</span>
-      <span class='ocrx_word' id='word_1_20' title='bbox 396 770 511 806; x_wconf 96'>Three</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_8' title="bbox 221 828 377 862">
-    <p class='ocr_par' id='par_1_8' lang='eng' title="bbox 221 828 377 862">
-     <span class='ocr_line' id='line_1_8' title="bbox 221 828 377 862; baseline 0.013 -2; x_size 38.392159; x_descenders 5.3921571; x_ascenders 8">
-      <span class='ocrx_word' id='word_1_21' title='bbox 221 840 236 855; x_wconf 75'>e</span>
-      <span class='ocrx_word' id='word_1_22' title='bbox 271 828 377 862; x_wconf 96'>More</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_9' title="bbox 271 932 500 978">
-    <p class='ocr_par' id='par_1_9' lang='eng' title="bbox 271 932 500 978">
-     <span class='ocr_line' id='line_1_9' title="bbox 271 932 500 978; baseline 0.004 -11; x_size 46; x_descenders 10; x_ascenders 11">
-      <span class='ocrx_word' id='word_1_23' title='bbox 271 932 500 978; x_wconf 91'>Blockquote</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_10' title="bbox 145 1038 1979 1084">
-    <p class='ocr_par' id='par_1_10' lang='eng' title="bbox 145 1038 1979 1084">
-     <span class='ocr_line' id='line_1_10' title="bbox 145 1038 1979 1084; baseline 0 -10; x_size 44; x_descenders 8; x_ascenders 11">
-      <span class='ocrx_word' id='word_1_24' title='bbox 145 1038 231 1074; x_wconf 96'>And</span>
-      <span class='ocrx_word' id='word_1_25' title='bbox 245 1038 347 1081; x_wconf 95'>bold,</span>
-      <span class='ocrx_word' id='word_1_26' title='bbox 366 1038 495 1081; x_wconf 96'>italics,</span>
-      <span class='ocrx_word' id='word_1_27' title='bbox 513 1038 583 1074; x_wconf 96'>and</span>
-      <span class='ocrx_word' id='word_1_28' title='bbox 597 1049 689 1074; x_wconf 96'>even</span>
-      <span class='ocrx_word' id='word_1_29' title='bbox 705 1038 823 1074; x_wconf 96'>italics</span>
-      <span class='ocrx_word' id='word_1_30' title='bbox 838 1038 912 1074; x_wconf 96'>and</span>
-      <span class='ocrx_word' id='word_1_31' title='bbox 927 1038 1019 1074; x_wconf 96'>later</span>
-      <span class='ocrx_word' id='word_1_32' title='bbox 1032 1038 1129 1074; x_wconf 96'>bold.</span>
-      <span class='ocrx_word' id='word_1_33' title='bbox 1146 1040 1247 1074; x_wconf 92'>Even</span>
-      <span class='ocrx_word' id='word_1_34' title='bbox 1261 1038 1536 1084; x_wconf 63'>strikethreugh.</span>
-      <span class='ocrx_word' id='word_1_35' title='bbox 1552 1040 1588 1073; x_wconf 91'>A</span>
-      <span class='ocrx_word' id='word_1_36' title='bbox 1602 1038 1678 1073; x_wconf 91'>link</span>
-      <span class='ocrx_word' id='word_1_37' title='bbox 1691 1045 1728 1074; x_wconf 96'>to</span>
-      <span class='ocrx_word' id='word_1_38' title='bbox 1744 1038 1979 1074; x_wconf 96'>somewhere.</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_11' title="bbox 146 1157 502 1199">
-    <p class='ocr_par' id='par_1_11' lang='eng' title="bbox 146 1157 502 1199">
-     <span class='ocr_line' id='line_1_11' title="bbox 146 1157 502 1199; baseline 0.003 -1; x_size 47.40678; x_descenders 5.4067798; x_ascenders 13">
-      <span class='ocrx_word' id='word_1_39' title='bbox 146 1160 267 1199; x_wconf 95'>Here</span>
-      <span class='ocrx_word' id='word_1_40' title='bbox 283 1157 319 1199; x_wconf 96'>is</span>
-      <span class='ocrx_word' id='word_1_41' title='bbox 338 1170 364 1199; x_wconf 96'>a</span>
-      <span class='ocrx_word' id='word_1_42' title='bbox 381 1157 502 1199; x_wconf 96'>table</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_12' title="bbox 156 1292 872 1338">
-    <p class='ocr_par' id='par_1_12' lang='eng' title="bbox 156 1292 872 1338">
-     <span class='ocr_line' id='line_1_12' title="bbox 156 1292 872 1338; baseline 0.001 -11; x_size 46; x_descenders 10; x_ascenders 11">
-      <span class='ocrx_word' id='word_1_43' title='bbox 156 1294 278 1328; x_wconf 95'>Name</span>
-      <span class='ocrx_word' id='word_1_44' title='bbox 294 1292 431 1328; x_wconf 95'>Lunch</span>
-      <span class='ocrx_word' id='word_1_45' title='bbox 446 1292 562 1328; x_wconf 95'>order</span>
-      <span class='ocrx_word' id='word_1_46' title='bbox 604 1292 718 1338; x_wconf 96'>Spicy</span>
-      <span class='ocrx_word' id='word_1_47' title='bbox 759 1294 872 1328; x_wconf 86'>Owes</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_13' title="bbox 156 1362 526 1406">
-    <p class='ocr_par' id='par_1_13' lang='eng' title="bbox 156 1362 526 1406">
-     <span class='ocr_line' id='line_1_13' title="bbox 156 1362 526 1406; baseline 0 -10; x_size 44; x_descenders 10; x_ascenders 9">
-      <span class='ocrx_word' id='word_1_48' title='bbox 156 1362 245 1396; x_wconf 85'>Joan</span>
-      <span class='ocrx_word' id='word_1_49' title='bbox 294 1370 380 1406; x_wconf 85'>saag</span>
-      <span class='ocrx_word' id='word_1_50' title='bbox 395 1371 526 1406; x_wconf 96'>paneer</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_14' title="bbox 578 1359 870 1399">
-    <p class='ocr_par' id='par_1_14' lang='eng' title="bbox 578 1359 870 1399">
-     <span class='ocr_line' id='line_1_14' title="bbox 578 1359 870 1399; baseline -0.003 -3; x_size 41.392159; x_descenders 5.3921571; x_ascenders 11">
-      <span class='ocrx_word' id='word_1_51' title='bbox 578 1360 740 1396; x_wconf 75'>medium</span>
-      <span class='ocrx_word' id='word_1_52' title='bbox 802 1359 870 1399; x_wconf 75'>$11</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_15' title="bbox 158 1429 465 1475">
-    <p class='ocr_par' id='par_1_15' lang='eng' title="bbox 158 1429 465 1475">
-     <span class='ocr_line' id='line_1_15' title="bbox 158 1429 465 1475; baseline 0.003 -11; x_size 46; x_descenders 10; x_ascenders 11">
-      <span class='ocrx_word' id='word_1_53' title='bbox 158 1429 257 1475; x_wconf 89'>Sally</span>
-      <span class='ocrx_word' id='word_1_54' title='bbox 292 1429 465 1465; x_wconf 89'>vindaloo</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_16' title="bbox 578 1429 668 1465">
-    <p class='ocr_par' id='par_1_16' lang='eng' title="bbox 578 1429 668 1465">
-     <span class='ocr_line' id='line_1_16' title="bbox 578 1429 668 1465; baseline 0.022 -2; x_size 41.759998; x_descenders 5.7599998; x_ascenders 12">
-      <span class='ocrx_word' id='word_1_55' title='bbox 578 1429 668 1465; x_wconf 96'>mild</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_17' title="bbox 800 1428 872 1468">
-    <p class='ocr_par' id='par_1_17' lang='eng' title="bbox 800 1428 872 1468">
-     <span class='ocr_line' id='line_1_17' title="bbox 800 1428 872 1468; baseline -0.056 -1; x_size 52; x_descenders 13; x_ascenders 13">
-      <span class='ocrx_word' id='word_1_56' title='bbox 800 1428 872 1468; x_wconf 96'>$14</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_18' title="bbox 156 1500 240 1533">
-    <p class='ocr_par' id='par_1_18' lang='eng' title="bbox 156 1500 240 1533">
-     <span class='ocr_line' id='line_1_18' title="bbox 156 1500 240 1533; baseline 0 0; x_size 38.387756; x_descenders 5.3877549; x_ascenders 9">
-      <span class='ocrx_word' id='word_1_57' title='bbox 156 1500 240 1533; x_wconf 96'>Erin</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_19' title="bbox 293 1498 679 1534">
-    <p class='ocr_par' id='par_1_19' lang='eng' title="bbox 293 1498 679 1534">
-     <span class='ocr_line' id='line_1_19' title="bbox 293 1498 679 1534; baseline 0 0; x_size 41.392159; x_descenders 5.3921571; x_ascenders 11">
-      <span class='ocrx_word' id='word_1_58' title='bbox 293 1498 390 1534; x_wconf 94'>lamb</span>
-      <span class='ocrx_word' id='word_1_59' title='bbox 406 1498 548 1534; x_wconf 94'>madras</span>
-      <span class='ocrx_word' id='word_1_60' title='bbox 578 1500 679 1534; x_wconf 96'>HOT</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_20' title="bbox 825 1497 871 1537">
-    <p class='ocr_par' id='par_1_20' lang='eng' title="bbox 825 1497 871 1537">
-     <span class='ocr_line' id='line_1_20' title="bbox 825 1497 871 1537; baseline -0.065 0; x_size 49.333332; x_descenders 12.333333; x_ascenders 12.333333">
-      <span class='ocrx_word' id='word_1_61' title='bbox 825 1497 871 1537; x_wconf 96'>$5</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_21' title="bbox 147 1613 700 1649">
-    <p class='ocr_par' id='par_1_21' lang='eng' title="bbox 147 1613 700 1649">
-     <span class='ocr_line' id='line_1_21' title="bbox 147 1613 700 1649; baseline 0.002 -1; x_size 40.387756; x_descenders 5.3877549; x_ascenders 11">
-      <span class='ocrx_word' id='word_1_62' title='bbox 147 1615 197 1649; x_wconf 95'>Or</span>
-      <span class='ocrx_word' id='word_1_63' title='bbox 212 1613 323 1649; x_wconf 95'>inline</span>
-      <span class='ocrx_word' id='word_1_64' title='bbox 339 1613 430 1649; x_wconf 96'>code</span>
-      <span class='ocrx_word' id='word_1_65' title='bbox 445 1613 518 1649; x_wconf 96'>like</span>
-      <span class='ocrx_word' id='word_1_66' title='bbox 533 1625 603 1649; x_wconf 95'>var</span>
-      <span class='ocrx_word' id='word_1_67' title='bbox 633 1617 700 1649; x_wconf 95'>foo</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_22' title="bbox 729 1629 750 1633">
-    <p class='ocr_par' id='par_1_22' lang='eng' title="bbox 729 1629 750 1633">
-     <span class='ocr_line' id='line_1_22' title="bbox 729 1629 750 1633; textangle 90; x_size 29.333334; x_descenders 7.3333335; x_ascenders 7.3333335">
-      <span class='ocrx_word' id='word_1_68' title='bbox 729 1629 750 1633; x_wconf 44'>I</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_23' title="bbox 786 1617 932 1654">
-    <p class='ocr_par' id='par_1_23' lang='eng' title="bbox 786 1617 932 1654">
-     <span class='ocr_line' id='line_1_23' title="bbox 786 1617 932 1654; baseline 0 -5; x_size 37.387756; x_descenders 5.3877549; x_ascenders 8">
-      <span class='ocrx_word' id='word_1_69' title='bbox 786 1617 932 1654; x_wconf 45'>‘bar&#39;;.</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_24' title="bbox 147 1720 563 1766">
-    <p class='ocr_par' id='par_1_24' lang='eng' title="bbox 147 1720 563 1766">
-     <span class='ocr_line' id='line_1_24' title="bbox 147 1720 563 1766; baseline 0.002 -11; x_size 46; x_descenders 10; x_ascenders 11">
-      <span class='ocrx_word' id='word_1_70' title='bbox 147 1722 197 1756; x_wconf 96'>Or</span>
-      <span class='ocrx_word' id='word_1_71' title='bbox 213 1731 257 1756; x_wconf 96'>an</span>
-      <span class='ocrx_word' id='word_1_72' title='bbox 271 1722 391 1766; x_wconf 95'>image</span>
-      <span class='ocrx_word' id='word_1_73' title='bbox 407 1720 447 1756; x_wconf 95'>of</span>
-      <span class='ocrx_word' id='word_1_74' title='bbox 459 1720 563 1756; x_wconf 96'>bears</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_25' title="bbox 390 1817 446 1825">
-    <p class='ocr_par' id='par_1_25' lang='eng' title="bbox 390 1817 446 1825">
-     <span class='ocr_line' id='line_1_25' title="bbox 390 1817 446 1825; baseline 0 0; x_size 20; x_descenders 5; x_ascenders 5">
-      <span class='ocrx_word' id='word_1_75' title='bbox 400 1807 414 1835; x_wconf 0'>~—</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_26' title="bbox 158 1895 258 1904">
-    <p class='ocr_par' id='par_1_26' lang='eng' title="bbox 158 1895 258 1904">
-     <span class='ocr_line' id='line_1_26' title="bbox 158 1895 258 1904; baseline 0.01 -3; x_size 20; x_descenders 5; x_ascenders 5">
-      <span class='ocrx_word' id='word_1_76' title='bbox 158 1895 258 1904; x_wconf 23'>=</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_27' title="bbox 170 1955 223 1961">
-    <p class='ocr_par' id='par_1_27' lang='eng' title="bbox 170 1955 223 1961">
-     <span class='ocr_line' id='line_1_27' title="bbox 170 1955 223 1961; baseline 0 -1; x_size 20; x_descenders 5; x_ascenders 5">
-      <span class='ocrx_word' id='word_1_77' title='bbox 170 1955 223 1961; x_wconf 0'>=</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_28' title="bbox 395 1987 430 2021">
-    <p class='ocr_par' id='par_1_28' lang='eng' title="bbox 395 1987 430 2021">
-     <span class='ocr_line' id='line_1_28' title="bbox 395 1987 430 2021; baseline 0 0; x_size 45.333332; x_descenders 11.333333; x_ascenders 11.333334">
-      <span class='ocrx_word' id='word_1_78' title='bbox 395 1987 430 2021; x_wconf 50'>7</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_29' title="bbox 427 2056 453 2082">
-    <p class='ocr_par' id='par_1_29' lang='eng' title="bbox 427 2056 453 2082">
-     <span class='ocr_line' id='line_1_29' title="bbox 427 2056 453 2082; baseline 0 0; x_size 36; x_descenders 9; x_ascenders 9">
-      <span class='ocrx_word' id='word_1_79' title='bbox 437 2051 449 2095; x_wconf 32'>ij</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_30' title="bbox 549 2025 648 2080">
-    <p class='ocr_par' id='par_1_30' lang='eng' title="bbox 549 2025 648 2080">
-     <span class='ocr_line' id='line_1_30' title="bbox 549 2025 648 2080; baseline -0.01 0; x_size 68; x_descenders 13; x_ascenders 15">
-      <span class='ocrx_word' id='word_1_80' title='bbox 549 2025 648 2080; x_wconf 14'>SN!</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_31' title="bbox 529 2236 577 2277">
-    <p class='ocr_par' id='par_1_31' lang='eng' title="bbox 529 2236 577 2277">
-     <span class='ocr_line' id='line_1_31' title="bbox 529 2236 577 2277; baseline -0.104 0; x_size 48; x_descenders 12; x_ascenders 12">
-      <span class='ocrx_word' id='word_1_81' title='bbox 529 2236 577 2277; x_wconf 84'>&gt;</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_32' title="bbox 146 2501 308 2537">
-    <p class='ocr_par' id='par_1_32' lang='eng' title="bbox 146 2501 354 2537">
-     <span class='ocr_line' id='line_1_32' title="bbox 146 2501 308 2537; baseline 0.005 -1; x_size 41.392159; x_descenders 5.3921571; x_ascenders 11">
-      <span class='ocrx_word' id='word_1_82' title='bbox 146 2501 222 2537; x_wconf 96'>The</span>
-      <span class='ocrx_word' id='word_1_83' title='bbox 238 2501 354 2537; x_wconf 87'>end...</span>
-     </span>
-    </p>
-   </div>
-   <div class='ocr_carea' id='block_1_33' title="bbox 147 2607 317 2653">
-    <p class='ocr_par' id='par_1_33' lang='eng' title="bbox 147 2607 317 2653">
-     <span class='ocr_line' id='line_1_33' title="bbox 147 2607 317 2653; baseline -0.006 -10; x_size 47; x_descenders 11; x_ascenders 11">
-      <span class='ocrx_word' id='word_1_84' title='bbox 147 2607 317 2653; x_wconf 92'>613Corg</span>
-     </span>
-    </p>
-   </div>
-  </div>
- </body>
+<?xml version="1.0" ?>
+<html>
+	<head>
+		<meta content="Converted from PDF by pdftotree 0.5.1+dev" name="ocr-system"/>
+		<meta content="ocr_page ocr_table ocrx_block ocrx_line ocrx_word" name="ocr-capabilities"/>
+		<meta content="1" name="ocr-number-of-pages"/>
+	</head>
+	<body>
+		<div class="ocr_page" id="page_1" title="bbox 0 0 612 792; ppageno 0">
+			<div class="ocrx_block" pdftotree="header" title="bbox 35 37 231 61">
+				<span class="ocrx_line" title="bbox 35 37 231 61">
+					<span class="ocrx_word" title="bbox 35 37 111 61">Sample</span>
+					<span class="ocrx_word" title="bbox 117 37 231 61">Markdown</span>
+				</span>
+			</div>
+			<div class="ocrx_block" pdftotree="section_header" title="bbox 35 79 220 91">
+				<span class="ocrx_line" title="bbox 35 79 220 91">
+					<span class="ocrx_word" title="bbox 35 79 56 91">This</span>
+					<span class="ocrx_word" title="bbox 59 79 67 91">is</span>
+					<span class="ocrx_word" title="bbox 70 79 95 91">some</span>
+					<span class="ocrx_word" title="bbox 98 79 126 91">basic,</span>
+					<span class="ocrx_word" title="bbox 129 79 163 91">sample</span>
+					<span class="ocrx_word" title="bbox 166 79 220 91">markdown.</span>
+				</span>
+			</div>
+			<div class="ocrx_block" pdftotree="section_header" title="bbox 35 108 159 126">
+				<span class="ocrx_line" title="bbox 35 108 159 126">
+					<span class="ocrx_word" title="bbox 35 108 90 126">Second</span>
+					<span class="ocrx_word" title="bbox 94 108 159 126">Heading</span>
+				</span>
+			</div>
+			<div class="ocrx_block" pdftotree="section_header" title="bbox 65 143 165 155">
+				<span class="ocrx_line" title="bbox 65 143 165 155">
+					<span class="ocrx_word" title="bbox 65 143 116 155">Unordered</span>
+					<span class="ocrx_word" title="bbox 119 143 141 155">lists,</span>
+					<span class="ocrx_word" title="bbox 144 143 165 155">and:</span>
+				</span>
+			</div>
+			<div class="ocrx_block" pdftotree="paragraph" title="bbox 83 156 122 195">
+				<span class="ocrx_line" title="bbox 83 156 114 168">
+					<span class="ocrx_word" title="bbox 83 156 92 168">1.</span>
+					<span class="ocrx_word" title="bbox 95 156 114 168">One</span>
+				</span>
+				<span class="ocrx_line" title="bbox 83 170 116 182">
+					<span class="ocrx_word" title="bbox 83 170 92 182">2.</span>
+					<span class="ocrx_word" title="bbox 95 170 116 182">Two</span>
+				</span>
+				<span class="ocrx_line" title="bbox 83 183 122 195">
+					<span class="ocrx_word" title="bbox 83 183 92 195">3.</span>
+					<span class="ocrx_word" title="bbox 95 183 122 195">Three</span>
+				</span>
+			</div>
+			<div class="ocrx_block" pdftotree="section_header" title="bbox 65 197 90 209">
+				<span class="ocrx_line" title="bbox 65 197 90 209">
+					<span class="ocrx_word" title="bbox 65 197 90 209">More</span>
+				</span>
+			</div>
+			<div class="ocrx_block" pdftotree="section_header" title="bbox 65 222 120 234">
+				<span class="ocrx_line" title="bbox 65 222 120 234">
+					<span class="ocrx_word" title="bbox 65 222 120 234">Blockquote</span>
+				</span>
+			</div>
+			<div class="ocrx_block" pdftotree="section_header" title="bbox 35 248 475 260">
+				<span class="ocrx_line" title="bbox 35 248 475 260">
+					<span class="ocrx_word" title="bbox 35 248 55 260">And</span>
+					<span class="ocrx_word" title="bbox 58 248 84 260">bold,</span>
+					<span class="ocrx_word" title="bbox 87 248 119 260">italics,</span>
+					<span class="ocrx_word" title="bbox 122 248 139 260">and</span>
+					<span class="ocrx_word" title="bbox 142 248 165 260">even</span>
+					<span class="ocrx_word" title="bbox 168 248 197 260">italics</span>
+					<span class="ocrx_word" title="bbox 200 248 218 260">and</span>
+					<span class="ocrx_word" title="bbox 221 248 244 260">later</span>
+					<span class="ocrx_word" title="bbox 247 248 271 260">bold.</span>
+					<span class="ocrx_word" title="bbox 274 248 299 260">Even</span>
+					<span class="ocrx_word" title="bbox 302 248 369 260">strikethrough.</span>
+					<span class="ocrx_word" title="bbox 372 248 381 260">A</span>
+					<span class="ocrx_word" title="bbox 384 248 402 260">link</span>
+					<span class="ocrx_word" title="bbox 405 248 415 260">to</span>
+					<span class="ocrx_word" title="bbox 418 248 475 260">somewhere.</span>
+				</span>
+			</div>
+			<div class="ocrx_block" pdftotree="section_header" title="bbox 35 276 120 290">
+				<span class="ocrx_line" title="bbox 35 276 120 290">
+					<span class="ocrx_word" title="bbox 35 276 64 290">Here</span>
+					<span class="ocrx_word" title="bbox 67 276 77 290">is</span>
+					<span class="ocrx_word" title="bbox 80 276 87 290">a</span>
+					<span class="ocrx_word" title="bbox 91 276 120 290">table</span>
+				</span>
+			</div>
+			<table class="ocr_table" title="bbox 37 309 209 370">
+				<tr>
+					<td title="bbox 37 311 136 318">
+						<span class="ocrx_line" title="bbox 37 309 135 321">
+							<span class="ocrx_word" title="bbox 37 309 67 321">Name</span>
+							<span class="ocrx_word" title="bbox 70 309 103 321">Lunch</span>
+							<span class="ocrx_word" title="bbox 106 309 135 321">order</span>
+						</span>
+					</td>
+					<td title="bbox 144 311 173 318">
+						<span class="ocrx_line" title="bbox 144 309 172 321">
+							<span class="ocrx_word" title="bbox 144 309 172 321">Spicy</span>
+						</span>
+					</td>
+					<td title="bbox 181 311 205 318">
+						<span class="ocrx_line" title="bbox 181 309 209 321">
+							<span class="ocrx_word" title="bbox 181 309 209 321">Owes</span>
+						</span>
+					</td>
+				</tr>
+				<tr>
+					<td title="bbox 37 328 128 334">
+						<span class="ocrx_line" title="bbox 37 325 59 337">
+							<span class="ocrx_word" title="bbox 37 325 59 337">Joan</span>
+						</span>
+						<span class="ocrx_line" title="bbox 70 325 126 337">
+							<span class="ocrx_word" title="bbox 70 325 91 337">saag</span>
+							<span class="ocrx_word" title="bbox 94 325 126 337">paneer</span>
+						</span>
+					</td>
+					<td title="bbox 138 328 179 334">
+						<span class="ocrx_line" title="bbox 138 325 177 337">
+							<span class="ocrx_word" title="bbox 138 325 177 337">medium</span>
+						</span>
+					</td>
+					<td title="bbox 192 328 209 334">
+						<span class="ocrx_line" title="bbox 192 325 209 337">
+							<span class="ocrx_word" title="bbox 192 325 209 337">$11</span>
+						</span>
+					</td>
+				</tr>
+				<tr>
+					<td title="bbox 37 344 113 351">
+						<span class="ocrx_line" title="bbox 37 342 61 354">
+							<span class="ocrx_word" title="bbox 37 342 61 354">Sally</span>
+						</span>
+						<span class="ocrx_line" title="bbox 70 342 112 354">
+							<span class="ocrx_word" title="bbox 70 342 112 354">vindaloo</span>
+						</span>
+					</td>
+					<td title="bbox 138 344 162 351">
+						<span class="ocrx_line" title="bbox 138 342 160 354">
+							<span class="ocrx_word" title="bbox 138 342 160 354">mild</span>
+						</span>
+					</td>
+					<td title="bbox 191 344 209 351">
+						<span class="ocrx_line" title="bbox 191 342 209 354">
+							<span class="ocrx_word" title="bbox 191 342 209 354">$14</span>
+						</span>
+					</td>
+				</tr>
+				<tr>
+					<td title="bbox 37 361 133 367">
+						<span class="ocrx_line" title="bbox 37 358 57 370">
+							<span class="ocrx_word" title="bbox 37 358 57 370">Erin</span>
+						</span>
+					</td>
+					<td/>
+					<td title="bbox 197 361 209 367">
+						<span class="ocrx_line" title="bbox 197 358 209 370">
+							<span class="ocrx_word" title="bbox 197 358 209 370">$5</span>
+						</span>
+					</td>
+				</tr>
+			</table>
+			<div class="ocrx_block" pdftotree="section_header" title="bbox 35 386 224 398">
+				<span class="ocrx_line" title="bbox 35 386 224 398">
+					<span class="ocrx_word" title="bbox 35 386 47 398">Or</span>
+					<span class="ocrx_word" title="bbox 50 386 77 398">inline</span>
+					<span class="ocrx_word" title="bbox 80 386 103 398">code</span>
+					<span class="ocrx_word" title="bbox 106 386 124 398">like</span>
+					<span class="ocrx_word" title="bbox 127 388 145 398">var</span>
+					<span class="ocrx_word" title="bbox 151 388 168 398">foo</span>
+					<span class="ocrx_word" title="bbox 174 388 180 398">=</span>
+					<span class="ocrx_word" title="bbox 186 386 224 398">&amp;#x27;bar&amp;#x27;;.</span>
+				</span>
+			</div>
+			<div class="ocrx_block" pdftotree="section_header" title="bbox 35 411 135 423">
+				<span class="ocrx_line" title="bbox 35 411 135 423">
+					<span class="ocrx_word" title="bbox 35 411 47 423">Or</span>
+					<span class="ocrx_word" title="bbox 50 411 61 423">an</span>
+					<span class="ocrx_word" title="bbox 64 411 94 423">image</span>
+					<span class="ocrx_word" title="bbox 97 411 107 423">of</span>
+					<span class="ocrx_word" title="bbox 110 411 135 423">bears</span>
+				</span>
+			</div>
+			<figure title="bbox 35 436 185 586"/>
+			<div class="ocrx_block" pdftotree="section_header" title="bbox 35 599 85 611">
+				<span class="ocrx_line" title="bbox 35 599 85 611">
+					<span class="ocrx_word" title="bbox 35 599 53 611">The</span>
+					<span class="ocrx_word" title="bbox 56 599 73 611">end</span>
+					<span class="ocrx_word" title="bbox 76 599 85 611">...</span>
+				</span>
+			</div>
+			<div class="ocrx_block" pdftotree="section_header" title="bbox 35 624 76 636">
+				<span class="ocrx_line" title="bbox 35 624 76 636">
+					<span class="ocrx_word" title="bbox 35 624 76 636">δ13Corg</span>
+				</span>
+			</div>
+		</div>
+	</body>
 </html>

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -922,20 +922,7 @@ def test_parse_hocr():
     )
     doc = parser_udf.apply(doc)
     assert doc.name == "md"
-    assert doc.sentences[12].left == [
-        145,
-        245,
-        245,
-        366,
-        366,
-        513,
-        597,
-        705,
-        838,
-        927,
-        1032,
-        1032,
-    ]
+    assert doc.sentences[12].left == [372, 384, 405, 418, 418]
     assert doc.sentences[12].page == [1] * len(doc.sentences[12].words)
 
     docs_path = "tests/data/hocr_simple/121.hocr"

--- a/tests/parser/test_preprocessor.py
+++ b/tests/parser/test_preprocessor.py
@@ -13,7 +13,7 @@ def test_hocrpreprocessor():
     # the intermidiate attribute: "fonduer" should be removed.
     assert "fonduer" not in doc.text
     # number of "left" attribute is equal to that of "ppageno" - 1 (at ocr_page)
-    assert doc.text.count("left") == doc.text.count("ppageno") - 1 == 33
+    assert doc.text.count("left") == doc.text.count("ppageno") - 1 == 24
 
 
 def test_hocrpreprocessor_space_false():


### PR DESCRIPTION
##  Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

Currently, parser unwraps "ocr_line" as Fonduer has no data model for lines.
However, hOCR could contains "ocrx_line" for lines.
Fonduer should unwrap this element as well for the same reason.

**Does your pull request fix any issue.**

N/A

## Description of the proposed changes

Unwrap "ocrx_line" as well as "ocr_line" as Fonduer has no data model 

## Test plan

Use pdftotree (https://github.com/HazyResearch/pdftotree/pull/95) to convert md.pdf to md.hocr, which contains "ocrx_line" elements.
And check if md.hocr can be correctly parsed.

## Checklist

* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [ ] I have updated the CHANGELOG.rst accordingly.