### PR TITLE
 Use spaCy v2.3.0 or later to use HocrVisualParser

### DIFF
--- a/src/fonduer/parser/visual_parser/hocr_visual_parser.py
+++ b/src/fonduer/parser/visual_parser/hocr_visual_parser.py
@@ -23,14 +23,13 @@ class HocrVisualParser(VisualParser):
     ):
         """Initialize a visual parser.
 
-        :raises ImportError: an error is raised when spaCy is not 2.2.2 or later.
+        :raises ImportError: an error is raised when spaCy is not 2.3.0 or later.
         """
-        if version.parse(spacy.__version__) < version.parse("2.2.2"):
+        if version.parse(spacy.__version__) < version.parse("2.3.0"):
             raise ImportError(
-                f"You are using spaCy {spacy.__version__},"
-                f"but it should be 2.2.2 or later."
+                f"You are using spaCy {spacy.__version__}, "
+                f"but it should be 2.3.0 or later to use HocrVisualParser."
             )
-        spacy.gold.USE_NEW_ALIGN = True
         self.replacements: List[Tuple[Pattern, str]] = []
         for (pattern, replace) in replacements:
             self.replacements.append((re.compile(pattern, flags=re.UNICODE), replace))

--- a/tests/data/hocr_simple/121.hocr
+++ b/tests/data/hocr_simple/121.hocr
@@ -51,7 +51,8 @@
           <span class="ocrx_word" id="word_1_67" title="bbox 358 193 366 201">of</span>
           <span class="ocrx_word" id="word_1_68" title="bbox 369 193 384 201">this</span>
           <span class="ocrx_word" id="word_1_69" title="bbox 387 193 426 201">Account.</span>
-          <span class="ocrx_word" id="word_1_70" title="bbox 430 193 453 202">“We,”</span>
+          <!--Use two single-quotes to see if #527 happens-->
+          <span class="ocrx_word" id="word_1_70" title="bbox 430 193 453 202">''We,''</span>
           <span class="ocrx_word" id="word_1_71" title="bbox 457 193 478 202">“Us,”</span>
           <span class="ocrx_word" id="word_1_72" title="bbox 482 193 504 201">“Our”</span>
           <span class="ocrx_word" id="word_1_73" title="bbox 508 193 524 201">and</span>


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

See #527

**Does your pull request fix any issue.**

Fix #527

## Description of the proposed changes

Raise an ImportError when spacy < 2.3.0 to make sure spacy v2.3.0 or later is used for HocrVisualParser

## Test plan

Introduce two consecutive single quotes `''` to one of the example hOCR files.

## Checklist

* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] I have updated the CHANGELOG.rst accordingly.
