### PR TITLE
Add multiline Japanese strings support to HocrVisualParser() to fix #534

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,9 @@ Changed
 
 Fixed
 ^^^^^
+* `@YasushiMiyata`_: Add multiline Japanese strings support to :class:`fonduer.parser.visual_parser.hocr_visual_parser`.
+  (`#534 <https://github.com/HazyResearch/fonduer/issues/534>`_)
+  (`#537 <https://github.com/HazyResearch/fonduer/pull/537>`_)
 * `@HiromuHota`_: Process the tail text only after child elements.
   (`#333 <https://github.com/HazyResearch/fonduer/issues/333>`_)
   (`#520 <https://github.com/HazyResearch/fonduer/pull/520>`_)

--- a/src/fonduer/parser/visual_parser/hocr_visual_parser.py
+++ b/src/fonduer/parser/visual_parser/hocr_visual_parser.py
@@ -117,21 +117,19 @@ class HocrVisualParser(VisualParser):
                             h2s_multi_idx = [
                                 k for k, v in h2s_multi.items() if ptr + i == v
                             ]
+                            start, end = 0, 0
                             if h2s_multi_idx:  # One hOCR word-to-multi spacy tokens
                                 start = h2s_multi_idx[0]
                                 end = h2s_multi_idx[-1] + 1
-                                # calculate a bbox that can include all
-                                left = min(lefts[start:end])
-                                top = min(tops[start:end])
-                                right = max(rights[start:end])
-                                bottom = max(bottoms[start:end])
-                                ppageno = ppagenos[start]
-                            else:
-                                raise RuntimeError(
-                                    "Tokens are not aligned!",
-                                    f"hocr tokens: {hocr_tokens}",
-                                    f"spacy tokens: {spacy_tokens}",
-                                )
+                            else:  # One hOCR word-to-multi spacy tokens
+                                start = s2h_multi[i - 1 if i > 0 else 0]
+                                end = s2h_multi[i + 1] + 1
+                            # calculate a bbox that can include all
+                            left = min(lefts[start:end])
+                            top = min(tops[start:end])
+                            right = max(rights[start:end])
+                            bottom = max(bottoms[start:end])
+                            ppageno = ppagenos[start]
                     # One-to-one mapping is available
                     else:
                         left = lefts[s2h[ptr + i]]

--- a/tests/data/hocr_simple/japan.hocr
+++ b/tests/data/hocr_simple/japan.hocr
@@ -75,6 +75,16 @@
      </span>
     </p>
    </div>
+   <div class='ocr_carea' id='block_1_2' title="bbox 145 175 245 185">
+    <p class='ocr_par' id='par_1_2' lang='jpn' title="bbox 145 175 245 185">
+     <span class="ocr_line" id="line_1_2" title="bbox 145 175 225 180">
+      <span class="ocrx_word" id="word_1_60" title="bbox 145 175 225 180; x_wconf 92">チェーン店</span>
+     </span>
+     <span class="ocr_line" id="line_1_3" title="bbox 226 181 245 185">
+      <span class="ocrx_word" id="word_1_61" title="bbox 226 181 245 185; x_wconf 92">本・支店</span>
+     </span>
+    </p>
+   </div>  
   </div>
  </body>
 </html>

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -955,6 +955,14 @@ def test_parse_hocr():
     assert sent.left[1] == 150  # this left comes from "に" in hOCR
     assert sent.right[1] == 249  # this right comes from "ぽん" in hOCR
 
+    sent = doc.sentences[2]
+    assert len(sent.words) == len(sent.left)
+    # "チェーン店\n本・支店" is tokenized into three: "チェーン店", "本・支店" in hOCR,
+    # but it is tokenized as "チェーン", "店本", "・", "支店" by spaCy.
+    assert sent.words[1] == "店本"
+    assert sent.left[1] == 145  # comes from left min of "チェーン店\n本・支店" in hOCR
+    assert sent.right[1] == 245  # comes from right min of "チェーン店\n本・支店" in hOCR
+
 
 def test_parse_hocr_with_tables():
     """Test the parser with hOCR documents that have tables."""


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**
See #534 

**Does your pull request fix any issue.**
Fix #534

## Description of the proposed changes
In case of multi line Japanese strings 'AAAA\nBBBB', spacy[ja] sometimes generates tokens ['AAA', 'AB', 'B', 'BB']. Proposal defines bbox of 'AB' as a multi line word (i.e. left is min left of ['A','B'], top is the top of 'A', right is max right of ['A','B'] and bottom is the bottom of 'B'). 

## Test plan
This is cause of Japanese morphological analysis. So, I have added  Japanese test data to 'tests/data/hocr_simple/japan.hocr' and test code to 'tests/parser/test_parser.py::test_parse_hocr'


## Checklist

* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.rst accordingly.
