### PR TITLE
docs: pin sphinx version to <4.0.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 sqlalchemy
+sphinx<4.0.0
 sphinx_autodoc_typehints
 deprecation
 sphinxcontrib-mermaid

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ pre-commit
 pytest
 pytest-dependency
 pytest-mock
-sphinx
+sphinx<4.0.0
 sphinx_rtd_theme
 sphinx_autodoc_typehints
 sphinxcontrib-mermaid


### PR DESCRIPTION
sphinx just released v4.0.1 yesterday, which breaks our CI pipeline. This is a quick patch to pin to versions that work.