### PR TITLE
Resolve memory leaks caused by add and commit to postgres (related to #494, redo #541)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ Added
   * `@YasushiMiyata`_: Add multiline Japanese strings support to :class:`fonduer.parser.visual_parser.hocr_visual_parser`.
   (`#534 <https://github.com/HazyResearch/fonduer/issues/534>`_)
   (`#542 <https://github.com/HazyResearch/fonduer/pull/542>`_)
+  * `@YasushiMiyata`_: Add commit process immediately after add to :class:`fonduer.parser.Parser`.
+  (`#494 <https://github.com/HazyResearch/fonduer/issues/494>`_)
+  (`#544 <https://github.com/HazyResearch/fonduer/pull/544>`_)
 
 Changed
 ^^^^^^^

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -133,6 +133,7 @@ class Parser(UDFRunner):
         # Persist the object if no error happens during parsing.
         if doc:
             self.session.add(doc)
+            self.session.commit()
 
     def clear(self) -> None:  # type: ignore
         """Clear all of the ``Context`` objects in the database."""


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**
Memory leaks happen when Fonduer adds and commits data to postgres after parsing many documents.
This causes OOM killer of Ubuntu and hangup Fonduer process. Please refer to #494.
(This PR is redo of #541)

**Does your pull request fix any issue.**
One of the memory leak problems is because sqlalchemy keeps all data, which are parsed from documents, on memory untill `commit` from `add`.

## Description of the proposed changes
Add `commit` immediately after `add` to free memory.
https://github.com/HazyResearch/fonduer/blob/b0154c36b4feeda2e81ad7dd9af7062762dad3bf/src/fonduer/parser/parser.py#L135
I’m definitely sure that no side effect happens because no processes exist with the data on the memory after `add` and `commit`.
By the way, there are two cases doing `commit` after multiple `add`; one is preparing a rollback of inserting data to postgres, and the other is accelerating insert processes for many small data. In contrast, document data in Fonduer are a few large data.

## Test plan
Run an existing tests (No additional tests).

## Checklist

* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.rst accordingly.
