### PR TITLE
Resolve a memory leak by large data on out_queue (related to #494)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,11 +34,11 @@ Changed
     * Removed ``visual``. Provide ``visual_parser`` if visual information is to be parsed.
 
 * `@YasushiMiyata`_: Changed :class:`UDFRunner`'s and :class:`UDF`'s data commit process as follows:
-(`#545 <https://github.com/HazyResearch/fonduer/pull/545>`_)
+  (`#545 <https://github.com/HazyResearch/fonduer/pull/545>`_)
 
-  * Removed ``add`` process in :func:`_apply` in :class:`UDFRunner`.
-  * Added ``add`` and ``commit`` of ``y`` to :class:`UDF`.
-  * Removed ``y`` of document parsed result from ``out_queue`` in :class:`UDF`.
+    * Removed ``add`` process in :func:`_apply` in :class:`UDFRunner`.
+    * Added ``add`` and ``commit`` of ``y`` to :class:`UDF`.
+    * Removed ``y`` of document parsed result from ``out_queue`` in :class:`UDF`.
 
 Fixed
 ^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,8 +36,8 @@ Changed
 * `@YasushiMiyata`_: Changed :class:`UDFRunner`'s and :class:`UDF`'s data commit process as follows:
   (`#545 <https://github.com/HazyResearch/fonduer/pull/545>`_)
 
-    * Removed ``add`` process in :func:`_apply` in :class:`UDFRunner`.
-    * Added ``add`` and ``commit`` of ``y`` to :class:`UDF`.
+    * Removed ``add`` process on single-thread in :func:`_apply` in :class:`UDFRunner`.
+    * Added ``UDFRunner._add`` of ``y`` on multi-threads to :class:`Parser`, :class:`Labeler` and :class:`Featurizer`.
     * Removed ``y`` of document parsed result from ``out_queue`` in :class:`UDF`.
 
 Fixed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,13 @@ Changed
     * Removed ``pdf_path``. Now this is required only by :class:`PdfVisualParser`.
     * Removed ``visual``. Provide ``visual_parser`` if visual information is to be parsed.
 
+* `@YasushiMiyata`_: Changed :class:`UDFRunner`'s and :class:`UDF`'s data commit process as follows:
+(`#545 <https://github.com/HazyResearch/fonduer/pull/545>`_)
+
+  * Removed ``add`` process in :func:`_apply` in :class:`UDFRunner`.
+  * Added ``add`` and ``commit`` of ``y`` to :class:`UDF`.
+  * Removed ``y`` of document parsed result from ``out_queue`` in :class:`UDF`.
+
 Fixed
 ^^^^^
 * `@YasushiMiyata`_: Fix test code `test_postgres.py::test_cand_gen_cascading_delete`.

--- a/src/fonduer/features/featurizer.py
+++ b/src/fonduer/features/featurizer.py
@@ -245,11 +245,11 @@ class Featurizer(UDFRunner):
         """
         return list(get_sparse_matrix_keys(self.session, FeatureKey))
 
-    def _add(self, records_list: List[List[Dict[str, Any]]]) -> None:
+    def _add(self, session: Session, records_list: List[List[Dict[str, Any]]]) -> None:
         # Make a flat list of all records from the list of list of records.
         # This helps reduce the number of queries needed to update.
         all_records = list(itertools.chain.from_iterable(records_list))
-        batch_upsert_records(self.session, Feature, all_records)
+        batch_upsert_records(session, Feature, all_records)
 
     def clear(self, train: bool = False, split: int = 0) -> None:  # type: ignore
         """Delete Features of each class from the database.

--- a/src/fonduer/parser/parser.py
+++ b/src/fonduer/parser/parser.py
@@ -129,11 +129,11 @@ class Parser(UDFRunner):
             progress_bar=progress_bar,
         )
 
-    def _add(self, doc: Union[Document, None]) -> None:
+    def _add(self, session: Session, doc: Union[Document, None]) -> None:
         # Persist the object if no error happens during parsing.
         if doc:
-            self.session.add(doc)
-            self.session.commit()
+            session.add(doc)
+            session.commit()
 
     def clear(self) -> None:  # type: ignore
         """Clear all of the ``Context`` objects in the database."""
@@ -156,6 +156,12 @@ class Parser(UDFRunner):
 
         :return: A list of all ``Documents`` in the database ordered by name.
         """
+        # return (
+        #     self.session.query(Document, Sentence)
+        #     .join(Sentence, Document.id == Sentence.document_id)
+        #     .all()
+        # )
+        # return self.session.query(Sentence).order_by(Sentence.name).all()
         return self.session.query(Document).order_by(Document.name).all()
 
 

--- a/src/fonduer/supervision/labeler.py
+++ b/src/fonduer/supervision/labeler.py
@@ -306,9 +306,9 @@ class Labeler(UDFRunner):
 
         drop_keys(self.session, LabelKey, key_map)
 
-    def _add(self, records_list: List[List[Dict[str, Any]]]) -> None:
+    def _add(self, session: Session, records_list: List[List[Dict[str, Any]]]) -> None:
         for records in records_list:
-            batch_upsert_records(self.session, self.table, records)
+            batch_upsert_records(session, self.table, records)
 
     def clear(  # type: ignore
         self,


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**
Fonduer accelerates parsing document with multi-processing. 
Each process gets documents from `in_queue` (shared memory), and puts parsed data and document name to `out_queue` (shared memory). 
This is well-known process, but possibility to hung up by memory leak of shared memory. 
Previous code put parsed (relatively large) data to `out_queue`.
From the `out_queue`, other process get the data and commit it to postges DB.
See also #494

**Does your pull request fix any issue.**
See #494

## Description of the proposed changes
Change `out_queue` input to only document name, not include parsed data. 
Instead of committing data with `out_queue`, each multi-thread process commits parsed data before putting document name to `out_queue`.

## Test plan
Do existing test and monitor python memory usage.
In my case (3000 html file, 12MB total), python memory usage reduce to 700MB from 1.4 GB.

## Checklist

* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.rst accordingly.
